### PR TITLE
synthesis prompt: describe erased metadata columns to the LLM

### DIFF
--- a/src/typologist/_pipeline.py
+++ b/src/typologist/_pipeline.py
@@ -93,6 +93,48 @@ def _l2_normalize(x: np.ndarray) -> np.ndarray:
     return x / norms
 
 
+_MAX_VALUES_SHOWN_IN_PROMPT = 8
+
+
+def _describe_erased_metadata(metadata: pd.DataFrame) -> list[dict]:
+    """Describe each metadata column for the synthesis prompt.
+
+    Type inference:
+    - ``pd.CategoricalDtype(ordered=True)`` -> ordinal (use declared category order)
+    - numeric dtypes -> ordinal (sorted unique values have a natural order)
+    - everything else -> categorical
+
+    Returns one dict per column with the fields consumed by
+    ``_format_accounted_for_entry`` in ``_prompts.py``.
+    """
+    out: list[dict] = []
+    for col in metadata.columns:
+        series = metadata[col]
+        if isinstance(series.dtype, pd.CategoricalDtype) and series.dtype.ordered:
+            col_type = "ordinal"
+            unique_all = [v for v in series.cat.categories if pd.notna(v)]
+        elif pd.api.types.is_numeric_dtype(series):
+            col_type = "ordinal"
+            unique_all = sorted(series.dropna().unique().tolist())
+        else:
+            col_type = "categorical"
+            unique_all = list(pd.unique(series.dropna()))
+
+        total_unique = len(unique_all)
+        truncated = total_unique > _MAX_VALUES_SHOWN_IN_PROMPT
+        shown = unique_all[:_MAX_VALUES_SHOWN_IN_PROMPT]
+        out.append(
+            {
+                "name": str(col),
+                "type": col_type,
+                "values_shown": [str(v) for v in shown],
+                "truncated": truncated,
+                "total_unique": total_unique,
+            }
+        )
+    return out
+
+
 def _erase_metadata(
     embeddings: np.ndarray,
     metadata: pd.DataFrame,
@@ -184,6 +226,7 @@ def _synthesize_field(
     object_description: str,
     corpus_description: str,
     prior_facet_names: list[str],
+    erased_metadata_descriptions: list[dict] | None = None,
 ) -> tuple[dict, str]:
     """Call ``schema_llm`` to propose a new facet from Toponymy cluster names.
 
@@ -198,6 +241,7 @@ def _synthesize_field(
         object_description=object_description,
         corpus_description=corpus_description,
         prior_facet_names=prior_facet_names,
+        erased_metadata_descriptions=erased_metadata_descriptions,
     )
 
     response = schema_llm.call_structured(prompt, _SCHEMA_FIELD_RESPONSE_SCHEMA)

--- a/src/typologist/_prompts.py
+++ b/src/typologist/_prompts.py
@@ -7,7 +7,7 @@ Clustered topics discovered in this corpus at multiple levels of granularity:
 
 {hierarchy_block}
 
-Identify a single categorical axis along which these {object_description} vary.{prior_facets_block}
+Identify a single categorical axis along which these {object_description} vary.{accounted_for_block}
 
 Respond with only valid JSON of the form:
 {{
@@ -41,16 +41,43 @@ Respond with the chosen value name only, no explanation.\
 """
 
 
+def _format_accounted_for_entry(entry: dict) -> str:
+    """Format one bullet of the accounted-for-axes block.
+
+    ``entry`` is one of:
+    - ``{"kind": "prior_facet", "name": str}``
+    - ``{"kind": "erased_metadata", "name": str, "type": "categorical" | "ordinal",
+         "values_shown": list[str], "truncated": bool, "total_unique": int}``
+    """
+    name = entry["name"]
+    if entry["kind"] == "prior_facet":
+        return f'- "{name}"'
+
+    values_joined = ", ".join(entry["values_shown"])
+    remaining = entry["total_unique"] - len(entry["values_shown"])
+    trailing = f", ... and {remaining} more" if entry["truncated"] else ""
+    if entry["type"] == "ordinal":
+        return f'- "{name}" (ordinal; ordered values: {values_joined}{trailing})'
+    return f'- "{name}" (categorical; values include: {values_joined}{trailing})'
+
+
 def render_synthesis_prompt(
     cluster_hierarchy: list[list[str]],
     object_description: str,
     corpus_description: str,
     prior_facet_names: list[str],
+    erased_metadata_descriptions: list[dict] | None = None,
 ) -> str:
     """Build the one-shot prompt that ``schema_llm`` sees when proposing a new facet.
 
     ``cluster_hierarchy`` is Toponymy's ``topic_names_``: layers from finest
     (layer 0) to coarsest.
+
+    ``erased_metadata_descriptions`` is an optional list of dicts produced by
+    ``_describe_erased_metadata`` describing columns the caller passed to
+    ``fit(metadata=...)``. They appear alongside prior facets in a unified
+    "do not re-propose" block so the LLM is steered off axes that have already
+    been accounted for, whether by Typologist itself or by the user.
     """
     hierarchy_lines: list[str] = []
     for i, layer in enumerate(cluster_hierarchy):
@@ -59,20 +86,27 @@ def render_synthesis_prompt(
             hierarchy_lines.append(f"  - {name}")
     hierarchy_block = "\n".join(hierarchy_lines)
 
-    if prior_facet_names:
-        joined = ", ".join(f'"{n}"' for n in prior_facet_names)
-        prior_facets_block = (
-            f"\n\nThe following axes have already been extracted from this corpus,"
-            f" so the one you propose should be orthogonal to all of them: {joined}."
+    entries: list[dict] = []
+    for name in prior_facet_names:
+        entries.append({"kind": "prior_facet", "name": name})
+    for desc in erased_metadata_descriptions or []:
+        entries.append({"kind": "erased_metadata", **desc})
+
+    if entries:
+        bullets = "\n".join(_format_accounted_for_entry(e) for e in entries)
+        accounted_for_block = (
+            "\n\nThe following axes have already been accounted for in this "
+            "corpus and should NOT be re-proposed. Propose an axis that is "
+            "orthogonal to all of them:\n" + bullets
         )
     else:
-        prior_facets_block = ""
+        accounted_for_block = ""
 
     return _SYNTHESIS_PROMPT.format(
         object_description=object_description,
         corpus_description=corpus_description,
         hierarchy_block=hierarchy_block,
-        prior_facets_block=prior_facets_block,
+        accounted_for_block=accounted_for_block,
     )
 
 

--- a/src/typologist/typologist.py
+++ b/src/typologist/typologist.py
@@ -10,6 +10,7 @@ from typologist._llm import _resolve_llm
 from typologist._pipeline import (
     _build_facet_diagnostics,
     _classify_docs,
+    _describe_erased_metadata,
     _erase_metadata,
     _normalize_inputs,
     _residualize_facet,
@@ -65,8 +66,10 @@ class Typologist:
 
         inputs = _normalize_inputs(documents, embeddings, metadata)
         working = inputs.embeddings
+        erased_metadata_descriptions: list[dict] | None = None
         if inputs.metadata is not None:
             working = _erase_metadata(working, inputs.metadata, inputs.was_normalized)
+            erased_metadata_descriptions = _describe_erased_metadata(inputs.metadata)
 
         schema: list[dict] = []
         label_series: list[pd.Series] = []
@@ -90,6 +93,7 @@ class Typologist:
                 object_description=self.object_description,
                 corpus_description=self.corpus_description,
                 prior_facet_names=[f["name"] for f in schema],
+                erased_metadata_descriptions=erased_metadata_descriptions,
             )
 
             labels = _classify_docs(

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -3,6 +3,7 @@ import pandas as pd
 import pytest
 
 from typologist._pipeline import (
+    _describe_erased_metadata,
     _erase_metadata,
     _is_l2_normalized,
     _l2_normalize,
@@ -183,3 +184,59 @@ def test_erase_metadata_preserves_dtype():
 
     assert _erase_metadata(x32, metadata, was_normalized=False).dtype == np.float32
     assert _erase_metadata(x64, metadata, was_normalized=False).dtype == np.float64
+
+
+def test_describe_erased_metadata_infers_string_column_as_categorical():
+    meta = pd.DataFrame({"color": ["red", "blue", "red", "green"]})
+    descs = _describe_erased_metadata(meta)
+    assert len(descs) == 1
+    assert descs[0]["name"] == "color"
+    assert descs[0]["type"] == "categorical"
+    assert set(descs[0]["values_shown"]) == {"red", "blue", "green"}
+    assert descs[0]["total_unique"] == 3
+    assert descs[0]["truncated"] is False
+
+
+def test_describe_erased_metadata_infers_numeric_column_as_ordinal():
+    meta = pd.DataFrame({"rating": [3.0, 1.0, 5.0, 2.0, 4.0, 3.0]})
+    descs = _describe_erased_metadata(meta)
+    assert descs[0]["type"] == "ordinal"
+    # sorted, deduplicated
+    assert descs[0]["values_shown"] == ["1.0", "2.0", "3.0", "4.0", "5.0"]
+
+
+def test_describe_erased_metadata_infers_ordered_categorical_as_ordinal():
+    meta = pd.DataFrame(
+        {
+            "size": pd.Categorical(
+                ["M", "S", "L", "M"],
+                categories=["S", "M", "L", "XL"],
+                ordered=True,
+            )
+        }
+    )
+    descs = _describe_erased_metadata(meta)
+    assert descs[0]["type"] == "ordinal"
+    assert descs[0]["values_shown"] == ["S", "M", "L", "XL"]
+
+
+def test_describe_erased_metadata_treats_unordered_categorical_as_categorical():
+    meta = pd.DataFrame(
+        {
+            "tag": pd.Categorical(
+                ["a", "b", "a"],
+                categories=["a", "b"],
+                ordered=False,
+            )
+        }
+    )
+    descs = _describe_erased_metadata(meta)
+    assert descs[0]["type"] == "categorical"
+
+
+def test_describe_erased_metadata_truncates_high_cardinality():
+    meta = pd.DataFrame({"country": [f"C{i:03d}" for i in range(50)]})
+    descs = _describe_erased_metadata(meta)
+    assert descs[0]["truncated"] is True
+    assert len(descs[0]["values_shown"]) == 8
+    assert descs[0]["total_unique"] == 50

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -30,14 +30,14 @@ def test_synthesis_prompt_renders_hierarchy_layers():
     assert "coarse_a" in out
 
 
-def test_synthesis_prompt_omits_prior_block_for_first_facet():
+def test_synthesis_prompt_omits_accounted_for_block_when_empty():
     out = render_synthesis_prompt(
         cluster_hierarchy=[["t"]],
         object_description="doc",
         corpus_description="corpus",
         prior_facet_names=[],
     )
-    assert "already been extracted" not in out
+    assert "already been accounted for" not in out
 
 
 def test_synthesis_prompt_includes_prior_facet_names():
@@ -47,9 +47,92 @@ def test_synthesis_prompt_includes_prior_facet_names():
         corpus_description="corpus",
         prior_facet_names=["contribution_type", "data_modality"],
     )
-    assert "already been extracted" in out
+    assert "already been accounted for" in out
     assert "contribution_type" in out
     assert "data_modality" in out
+
+
+def test_synthesis_prompt_describes_erased_categorical_metadata():
+    out = render_synthesis_prompt(
+        cluster_hierarchy=[["t"]],
+        object_description="doc",
+        corpus_description="corpus",
+        prior_facet_names=[],
+        erased_metadata_descriptions=[
+            {
+                "name": "product_category",
+                "type": "categorical",
+                "values_shown": ["Books", "Electronics", "All_Beauty"],
+                "truncated": False,
+                "total_unique": 3,
+            }
+        ],
+    )
+    assert "already been accounted for" in out
+    assert "product_category" in out
+    assert "categorical" in out
+    assert "Books, Electronics, All_Beauty" in out
+
+
+def test_synthesis_prompt_describes_erased_ordinal_metadata():
+    out = render_synthesis_prompt(
+        cluster_hierarchy=[["t"]],
+        object_description="doc",
+        corpus_description="corpus",
+        prior_facet_names=[],
+        erased_metadata_descriptions=[
+            {
+                "name": "rating",
+                "type": "ordinal",
+                "values_shown": ["1.0", "2.0", "3.0", "4.0", "5.0"],
+                "truncated": False,
+                "total_unique": 5,
+            }
+        ],
+    )
+    assert '"rating"' in out
+    assert "ordinal" in out
+    assert "ordered values: 1.0, 2.0, 3.0, 4.0, 5.0" in out
+
+
+def test_synthesis_prompt_shows_truncation_tail_for_high_cardinality_metadata():
+    out = render_synthesis_prompt(
+        cluster_hierarchy=[["t"]],
+        object_description="doc",
+        corpus_description="corpus",
+        prior_facet_names=[],
+        erased_metadata_descriptions=[
+            {
+                "name": "country",
+                "type": "categorical",
+                "values_shown": ["AR", "AT", "AU", "BE", "BR", "CA", "CH", "CN"],
+                "truncated": True,
+                "total_unique": 200,
+            }
+        ],
+    )
+    assert "... and 192 more" in out
+
+
+def test_synthesis_prompt_combines_prior_facets_and_erased_metadata():
+    out = render_synthesis_prompt(
+        cluster_hierarchy=[["t"]],
+        object_description="doc",
+        corpus_description="corpus",
+        prior_facet_names=["tone"],
+        erased_metadata_descriptions=[
+            {
+                "name": "product_category",
+                "type": "categorical",
+                "values_shown": ["Books"],
+                "truncated": False,
+                "total_unique": 1,
+            }
+        ],
+    )
+    assert "already been accounted for" in out
+    assert "tone" in out
+    assert "product_category" in out
 
 
 def test_synthesis_prompt_instructs_llm_not_to_include_other():


### PR DESCRIPTION
## Summary

When a user passes `metadata=` to `fit()`, LEACE erases those columns from the
embeddings but the synthesis LLM never hears about them. It knows about
facets Typologist has already discovered in the same fit, not about axes the
user pre-accounted for. So on the first facet, with no prior discoveries to
steer the LLM, it lands back on the dominant organizing axis and re-proposes
it almost verbatim (`primary_research_domain` when `primary_category` was
erased; `product_category` when `product_category` was erased).

This PR threads per-column descriptions through `_synthesize_field` so they
appear in the synthesis prompt alongside prior facets, in one unified "do
not re-propose" block. Each erased column is listed by:

- **Name** (e.g. `"product_category"`, `"rating"`)
- **Inferred type:** `ordinal` for numeric dtype or `pd.CategoricalDtype(ordered=True)`; `categorical` otherwise
- **Up to 8 example values**, ordered if ordinal, with a `... and N more` suffix when truncated

No API change. `Typologist.fit()` infers the descriptions from the passed
metadata DataFrame's dtypes. Users can cast explicitly to control
presentation.

## Measured effect

Four erase-mode experiments (n=500 each, 2 corpora x 2 seeds) comparing
against baseline runs without this change:

| erased column | type | max-NMI(any facet, curator) before | after | reduction |
|---|---|---|---|---|
| arxiv `primary_category` | categorical | 0.39 | 0.24 | -39% |
| amazon `product_category` | categorical | 0.58 | 0.15 | -74% |
| amazon `rating` | ordinal (1-5) | 0.42 | 0.38 | -8% |

The first-facet names shift meaningfully: amazon erase goes from
`product_category` -> `review_focus` as facet 0. arxiv erase goes from
`primary_research_domain` -> `research_contribution_type`.

The smaller effect on `rating` is expected and followed up in #1: the LLM
still proposes `reviewer_sentiment_orientation` because we told it "rating
accounted for" but not "avoid any sentiment axis," and dtype+values
inference can't bridge that gap. Richer user-supplied descriptions would.

## Scope

- This only nudges the synthesis step. LEACE still one-hots everything for
  embedding-side erasure.
- The per-document labeling step still reads the text directly, so it can
  still classify into sentiment-like values if the cluster the LLM named
  genuinely has sentiment structure in it.
- Experiment harness lives on separate `experiments/initial-corpora` and
  `experiments/synthesis-prompt-awareness` branches. Not pulled in here.

## Followup

- #1: accept user-provided descriptions for erased metadata columns (for the
  sentiment/rating case).

## Test plan

- [x] 106/106 existing tests pass
- [x] New tests for `_describe_erased_metadata` dtype inference (string -> categorical, numeric -> ordinal, ordered Categorical -> ordinal, unordered Categorical -> categorical, truncation at 8)
- [x] New tests for `render_synthesis_prompt` with categorical metadata, ordinal metadata, truncation tail, and combined with prior facets
- [x] Updated existing prompt tests for the sentinel-string change (`"already been extracted"` -> `"already been accounted for"`)