### PR TITLE
examples: runnable Amazon reviews walkthrough

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ scripts/smoke_fit.py
 # The experiments/ tree lives on experiments/* branches only; main otherwise
 # sees leftover artifacts + pycache from running those branches as untracked.
 experiments/
+
+# Generated DataMapPlot HTML from examples (regenerated on each run).
+examples/*.html

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ print(t.schema_)               # list[dict]: discovered facet definitions
 print(t.labels_df_)            # (n_docs, n_facets) DataFrame of categorical labels
 ```
 
+For a runnable end-to-end example against real data (500 Amazon reviews, Cohere embeddings, an interactive DataMapPlot of the result), see [`examples/amazon_reviews.py`](examples/amazon_reviews.py).
+
 ## Discovery with metadata erasure
 
 Pass a `metadata` DataFrame to erase known axes before discovery starts, so the facets Typologist finds are orthogonal to what you already had. A fuller example:

--- a/examples/amazon_reviews.py
+++ b/examples/amazon_reviews.py
@@ -8,8 +8,8 @@ Typologist does, start with Step 3's ~10-line block.
 What this does:
 1. Streams a stratified sample of ~500 Amazon reviews across 6 product
    categories from HuggingFace.
-2. Embeds the reviews with Cohere embed-v4.0. Swappable, see the
-   ``embed_documents`` docstring.
+2. Embeds the reviews locally with sentence-transformers all-MiniLM-L6-v2.
+   Swappable, see the ``embed_documents`` docstring.
 3. **Runs Typologist to discover 3 categorical facets.**
 4. Prints the discovered schema and a crosstab of facet 0 against the
    curator-assigned product category (to show the rediscovery effect).
@@ -18,15 +18,14 @@ What this does:
    assigned facet values followed by the review text itself.
 
 Expected runtime: ~5 minutes on a laptop.
-Expected cost: ~$3 (Cohere embedding + Anthropic LLM calls for schema
-synthesis and per-doc labeling).
+Expected cost: ~$3 (Anthropic LLM calls for schema synthesis and per-doc
+labeling; embedding runs locally and is free).
 
 Required environment variables:
-    CO_API_KEY         Cohere API key (swap if you use a different embedder)
     ANTHROPIC_API_KEY  Anthropic API key (Typologist's default LLM provider)
 
 Required extra installs (on top of `typologist` itself):
-    uv pip install datasets sentence-transformers cohere umap-learn datamapplot
+    uv pip install datasets sentence-transformers umap-learn datamapplot
 
 Run from the repo root:
     uv run python examples/amazon_reviews.py
@@ -34,7 +33,6 @@ Run from the repo root:
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
 
 import numpy as np
@@ -107,20 +105,30 @@ def load_reviews(seed: int) -> pd.DataFrame:
 
 
 def embed_documents(texts: list[str]) -> np.ndarray:
-    """Embed documents. **Swap this function if you don't use Cohere.**
+    """Embed documents. **Swap this function if you prefer a different embedder.**
 
     Typologist doesn't care which embedder produced its inputs. The only
     contract is: take ``list[str]`` of length n, return ``np.ndarray`` of
     shape ``(n, d)`` with floating-point dtype. The default below uses
-    Cohere embed-v4.0 (1536-dim) and reads ``CO_API_KEY`` from the env.
+    sentence-transformers' ``all-MiniLM-L6-v2`` (384-dim, local, free, CPU-
+    fine) because it keeps the example key-free beyond Anthropic.
 
     Two common alternatives you can paste in to replace this function:
 
-        # Sentence-Transformers (local, free, 768-dim):
-        from sentence_transformers import SentenceTransformer
+        # Cohere (remote, paid, 1536-dim; reads CO_API_KEY):
+        import cohere
         def embed_documents(texts):
-            model = SentenceTransformer("all-mpnet-base-v2")
-            return model.encode(texts, convert_to_numpy=True, show_progress_bar=True)
+            client = cohere.ClientV2()
+            parts = []
+            for i in range(0, len(texts), 96):
+                resp = client.embed(
+                    texts=texts[i:i+96],
+                    model="embed-v4.0",
+                    input_type="search_document",
+                    embedding_types=["float"],
+                )
+                parts.append(np.array(resp.embeddings.float_, dtype=np.float32))
+            return np.vstack(parts)
 
         # OpenAI (remote, paid, 1536-dim):
         import openai
@@ -129,22 +137,15 @@ def embed_documents(texts: list[str]) -> np.ndarray:
             resp = client.embeddings.create(model="text-embedding-3-small", input=texts)
             return np.array([d.embedding for d in resp.data], dtype=np.float32)
     """
-    import cohere
+    from sentence_transformers import SentenceTransformer
 
-    cohere_model = "embed-v4.0"
-    cohere_batch = 96
-
-    client = cohere.ClientV2(api_key=os.environ["CO_API_KEY"])
-    parts: list[np.ndarray] = []
-    for i in range(0, len(texts), cohere_batch):
-        resp = client.embed(
-            texts=texts[i : i + cohere_batch],
-            model=cohere_model,
-            input_type="search_document",
-            embedding_types=["float"],
-        )
-        parts.append(np.array(resp.embeddings.float_, dtype=np.float32))
-    return np.vstack(parts)
+    model = SentenceTransformer("all-MiniLM-L6-v2")
+    return model.encode(
+        texts,
+        convert_to_numpy=True,
+        normalize_embeddings=True,
+        show_progress_bar=True,
+    ).astype(np.float32)
 
 
 def _build_hover_text(
@@ -221,7 +222,7 @@ def main() -> None:
     print(f"  loaded {len(df)} reviews across {df['product_category'].nunique()} categories\n")
 
     # === Step 2: embed ===
-    print("Step 2: embedding with Cohere embed-v4.0...")
+    print("Step 2: embedding with sentence-transformers all-MiniLM-L6-v2...")
     embeddings = embed_documents(df["text"].tolist())
     print(f"  embeddings shape: {embeddings.shape}\n")
 
@@ -282,52 +283,51 @@ if __name__ == "__main__":
     main()
 
 
-# Sample output from a run on 2026-04-22 with seed=0. Facets 0 and 1
-# (product_category and review_sentiment) are stable across seeds; Facet 2
-# varies more (EVoC clustering is non-deterministic and the third facet is
-# the farthest from the embedding's dominant axes, so it picks up whichever
-# orthogonal structure the LLM finds most discriminating on a given run).
+# Sample output from a run on 2026-04-22 with seed=0 and MiniLM embeddings.
+# Facets 0 and 1 (product_category and review_sentiment) are stable across
+# seeds; Facet 2 varies more (EVoC clustering is non-deterministic and the
+# third facet is the farthest from the embedding's dominant axes, so it
+# picks up whichever orthogonal structure the LLM finds most discriminating
+# on a given run).
 #
 # === Discovered schema ===
 #
 # Facet 0: product_category (categorical)
-#   The broad product category that the Amazon review is describing.
-#   - books
-#   - toys
-#   - electronics
-#   - kitchen
-#   - apparel
-#   - footwear
-#   - personal_care
+#   The general product category that the Amazon review is about.
+#   - books_and_cookbooks
+#   - apparel_and_footwear
+#   - kitchen_and_cookware
+#   - toys_and_games
+#   - personal_care_and_beauty
 #   - hair_accessories
+#   - electronics_and_tech_accessories
 #   - Other
 #
 # Facet 1: review_sentiment (categorical)
-#   The overall sentiment and satisfaction level the reviewer expresses
-#   toward the product.
+#   The overall evaluative tone the reviewer expresses toward the product,
+#   independent of what the product is.
 #   - highly_positive
-#   - mostly_positive
-#   - mixed
-#   - mostly_negative
-#   - highly_negative
+#   - mixed_with_reservations
+#   - disappointed_negative
+#   - neutral_descriptive
 #   - Other
 #
 # Facet 2: review_focus_aspect (categorical)
-#   The primary product attribute or dimension the reviewer focuses their
-#   evaluation on.
-#   - physical_quality_and_durability
+#   The primary evaluative dimension the reviewer emphasizes when assessing
+#   the product.
 #   - fit_and_sizing
-#   - appearance_and_aesthetics
+#   - durability_and_build_quality
+#   - ease_of_use_and_assembly
+#   - value_for_money
+#   - sensory_experience
+#   - content_and_storytelling
 #   - functional_performance
-#   - value_for_price
-#   - customer_service_experience
-#   - ease_of_use_and_instructions
+#   - aesthetic_and_design
 #   - Other
 #
 # Facet 0's crosstab against Amazon's own product_category shows heavy
 # diagonal concentration and meaningful refinement: Typologist splits
-# Clothing_Shoes_and_Jewelry into apparel + footwear + hair_accessories, and
-# All_Beauty into personal_care + hair_accessories. That's arguably a
-# cleaner taxonomy than the original six-way split. Facets 1 and 2 add
-# sentiment and evaluation-focus axes that product_category alone doesn't
-# capture.
+# All_Beauty into personal_care + hair_accessories, and lumps
+# Clothing_Shoes_and_Jewelry's apparel/footwear into a single bucket with
+# hair_accessories pulled out. Facets 1 and 2 add sentiment and
+# evaluation-focus axes that product_category alone doesn't capture.

--- a/examples/amazon_reviews.py
+++ b/examples/amazon_reviews.py
@@ -125,10 +125,13 @@ def render_map(
     output_path: Path,
     seed: int,
 ) -> None:
-    """Run UMAP on the embeddings and render a multi-layer DataMapPlot.
+    """Run UMAP on the embeddings and render an interactive DataMapPlot.
 
-    Each facet in ``labels_df`` becomes a separate label layer in the
-    interactive plot, so the viewer can switch between colorings.
+    Each Typologist-discovered facet becomes one selectable colormap in the
+    ``colormaps=`` dict; a dropdown in the plot lets the viewer switch point
+    coloring between facets. Region text annotations (``*label_layers``) are
+    deliberately left off: the correct source for those is Toponymy fit on
+    the 2D coords, which is outside the scope of this example.
     """
     import datamapplot
     import umap
@@ -141,16 +144,14 @@ def render_map(
         random_state=seed,
     ).fit_transform(embeddings)
 
-    # Each column of labels_df (one per discovered facet) becomes one
-    # positional *label_layers argument to create_interactive_plot.
-    label_layers = [labels_df[col].astype(str).to_numpy() for col in labels_df.columns]
+    colormaps = {col: labels_df[col].astype(str).to_numpy() for col in labels_df.columns}
 
     fig = datamapplot.create_interactive_plot(
         coords,
-        *label_layers,
+        colormaps=colormaps,
         hover_text=hover_text,
-        title="Amazon reviews, colored by Typologist-discovered facets",
-        sub_title="Toggle layers to switch between facets.",
+        title="Amazon reviews",
+        sub_title="Point colors switchable between Typologist-discovered facets.",
         inline_data=True,
     )
     fig.save(str(output_path))
@@ -215,49 +216,48 @@ if __name__ == "__main__":
     main()
 
 
-# Sample output from a run on 2026-04-22 with seed=0 (exact wording varies
-# seed-to-seed because EVoC clustering is non-deterministic):
+# Sample output from a run on 2026-04-22 with seed=0. Facets 0 and 1
+# (product_category and review_sentiment) are stable across seeds; Facet 2
+# varies more (EVoC clustering is non-deterministic and the third facet is
+# the farthest from the embedding's dominant axes, so it picks up whichever
+# orthogonal structure the LLM finds most discriminating on a given run).
 #
 # === Discovered schema ===
 #
 # Facet 0: product_category (categorical)
-#   The category of product being reviewed, based on the item's primary use
-#   and market segment.
+#   The broad Amazon product category that the review pertains to.
+#   - electronics_and_tech
+#   - books
 #   - apparel_and_footwear
-#   - books_and_cookbooks
-#   - bags_and_luggage
-#   - electronics_and_accessories
-#   - kitchen_tools
 #   - beauty_and_personal_care
-#   - toys_and_plush
+#   - toys_and_games
+#   - kitchen_and_home
+#   - bags_and_accessories
 #   - Other
 #
 # Facet 1: review_sentiment (categorical)
-#   The overall sentiment the reviewer expresses toward the product, ranging
-#   from enthusiastic praise to strong dissatisfaction.
-#   - strongly_positive
-#   - mildly_positive
-#   - mixed
-#   - mildly_negative
-#   - strongly_negative
+#   The overall sentiment and evaluative tone the reviewer expresses about
+#   the product.
+#   - highly_positive
+#   - mixed_with_caveats
+#   - disappointed_negative
+#   - neutral_informational
 #   - Other
 #
-# Facet 2: review_focus_aspect (categorical)
-#   The primary product attribute the reviewer emphasizes when evaluating
-#   the item.
-#   - fit_and_sizing
-#   - durability_and_longevity
-#   - ease_of_use
-#   - value_for_money
-#   - aesthetic_appearance
-#   - performance_effectiveness
-#   - comfort_and_feel
-#   - instructions_and_setup
+# Facet 2: intended_user (categorical)
+#   Who the reviewer indicates the product was purchased for or used by.
+#   - self
+#   - child
+#   - spouse_or_partner
+#   - parent_or_elderly_relative
+#   - friend_as_gift
+#   - household_shared
 #   - Other
 #
 # Facet 0's crosstab against Amazon's own product_category shows heavy
 # diagonal concentration: Typologist rediscovers the curators' categorization
-# from the text alone, sometimes refining it further (Amazon's
-# Clothing_Shoes_and_Jewelry splits into apparel_and_footwear and
-# bags_and_luggage in the discovered schema). Facets 1 and 2 add orthogonal
-# axes that product_category alone doesn't capture.
+# from the text alone, and sometimes refines it (Amazon's
+# Clothing_Shoes_and_Jewelry splits into apparel_and_footwear + bags_and_
+# accessories; Electronics spills a bit into bags_and_accessories for tech
+# accessories/cases). Facets 1 and 2 add orthogonal axes that
+# product_category alone doesn't capture.

--- a/examples/amazon_reviews.py
+++ b/examples/amazon_reviews.py
@@ -245,7 +245,7 @@ def main() -> None:
     print(crosstab.to_string())
 
     print("\nRendering interactive map...")
-    hover = [doc[:200] for doc in df["text"].tolist()]
+    hover = [doc if len(doc) <= 500 else doc[:500] + "..." for doc in df["text"].tolist()]
     render_map(
         documents=df["text"].tolist(),
         embeddings=embeddings,

--- a/examples/amazon_reviews.py
+++ b/examples/amazon_reviews.py
@@ -167,8 +167,12 @@ def render_map(
         text_embedding_model=topic_embedder,
         # KMeans here rather than ToponymyClusterer because the version pair
         # (toponymy 0.5.x + current fast_hdbscan) has a boruvka signature
-        # drift that ToponymyClusterer hits; KMeans is simpler and adequate
-        # for spatial region labels on a 2D map.
+        # drift that ToponymyClusterer hits. Tracked upstream at
+        # TutteInstitute/toponymy#135 and in our own #4. KMeans is the demo
+        # clusterer (not Toponymy's recommended choice) and its layers are
+        # independent KMeans runs stitched into a tree post-hoc rather than
+        # a true density hierarchy, but it's adequate for 2D region labels
+        # here.
         clusterer=KMeansClusterer(min_clusters=5, base_n_clusters=20),
         object_description="product reviews",
         corpus_description="Amazon product reviews",

--- a/examples/amazon_reviews.py
+++ b/examples/amazon_reviews.py
@@ -1,10 +1,16 @@
 """Discover categorical facets in a sample of Amazon product reviews.
 
+**Step 3 is where Typologist actually runs.** Steps 1, 2, 4, and 5 are
+plumbing around this particular example (sampling Amazon reviews, embedding
+them, printing and visualizing the output). If you're skimming to see what
+Typologist does, start with Step 3's ~10-line block.
+
 What this does:
 1. Streams a stratified sample of ~500 Amazon reviews across 6 product
    categories from HuggingFace.
-2. Embeds the reviews with Cohere embed-v4.0.
-3. Runs Typologist to discover 3 categorical facets (the main event).
+2. Embeds the reviews with Cohere embed-v4.0. Swappable, see the
+   ``embed_documents`` docstring.
+3. **Runs Typologist to discover 3 categorical facets.**
 4. Prints the discovered schema and a crosstab of facet 0 against the
    curator-assigned product category (to show the rediscovery effect).
 5. Renders an interactive DataMapPlot HTML: point colors switch between
@@ -16,8 +22,8 @@ Expected cost: ~$3 (Cohere embedding + Anthropic LLM calls for schema
 synthesis and per-doc labeling).
 
 Required environment variables:
-    CO_API_KEY         Cohere API key, for embeddings
-    ANTHROPIC_API_KEY  Anthropic API key, for the three LLM roles
+    CO_API_KEY         Cohere API key (swap if you use a different embedder)
+    ANTHROPIC_API_KEY  Anthropic API key (Typologist's default LLM provider)
 
 Required extra installs (on top of `typologist` itself):
     uv pip install datasets sentence-transformers cohere umap-learn datamapplot
@@ -34,31 +40,9 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 
-# --- configuration ----------------------------------------------------------
-
-CATEGORIES = [
-    "Books",
-    "Electronics",
-    "All_Beauty",
-    "Clothing_Shoes_and_Jewelry",
-    "Home_and_Kitchen",
-    "Toys_and_Games",
-]
-N_PER_CATEGORY = 83  # 6 x 83 = 498 reviews total
-STREAM_WINDOW = 3000
-MIN_TEXT_CHARS = 200
-RANDOM_SEED = 0
-
-COHERE_MODEL = "embed-v4.0"
-COHERE_BATCH = 96
-
 OUTPUT_DIR = Path(__file__).parent
 HTML_OUTPUT = OUTPUT_DIR / "amazon_reviews_map.html"
-
-_AMAZON_JSONL_URL = (
-    "https://huggingface.co/datasets/McAuley-Lab/Amazon-Reviews-2023"
-    "/resolve/main/raw/review_categories/{category}.jsonl"
-)
+RANDOM_SEED = 0
 
 
 # --- helpers ----------------------------------------------------------------
@@ -67,34 +51,54 @@ _AMAZON_JSONL_URL = (
 def load_reviews(seed: int) -> pd.DataFrame:
     """Stream a stratified sample of Amazon reviews from HuggingFace.
 
-    For each category, streams the first STREAM_WINDOW rows from the public
-    JSONL dump, filters to verified purchases with text >= MIN_TEXT_CHARS,
-    and samples N_PER_CATEGORY rows. Returns a DataFrame with columns:
-    text, rating, product_category.
+    The ``SOURCE_PRODUCT_CATEGORIES`` list below is *input to sampling*, not
+    configuration for Typologist. We pick six Amazon-curator-assigned
+    product categories and draw a balanced number of reviews from each so
+    the corpus isn't dominated by one type. Typologist will then discover
+    its own categorization from the review text alone (see Step 3 in main).
     """
     from datasets import load_dataset
 
+    source_product_categories = [
+        "Books",
+        "Electronics",
+        "All_Beauty",
+        "Clothing_Shoes_and_Jewelry",
+        "Home_and_Kitchen",
+        "Toys_and_Games",
+    ]
+    n_per_category = 83  # 6 x 83 = ~498 reviews total
+    stream_window = 3000  # Stream this many per category before sampling
+    min_text_chars = 200  # Drop one-liner reviews; they embed poorly
+
+    jsonl_url = (
+        "https://huggingface.co/datasets/McAuley-Lab/Amazon-Reviews-2023"
+        "/resolve/main/raw/review_categories/{category}.jsonl"
+    )
+
     rng = np.random.default_rng(seed)
     parts: list[pd.DataFrame] = []
-
-    for category in CATEGORIES:
+    for category in source_product_categories:
         print(f"  streaming {category}...", flush=True)
-        url = _AMAZON_JSONL_URL.format(category=category)
-        ds = load_dataset("json", data_files=url, split="train", streaming=True)
-
+        ds = load_dataset(
+            "json",
+            data_files=jsonl_url.format(category=category),
+            split="train",
+            streaming=True,
+        )
         rows: list[dict] = []
         for row in ds:
             text = row.get("text") or ""
             if (
                 row.get("verified_purchase")
-                and len(text) >= MIN_TEXT_CHARS
+                and len(text) >= min_text_chars
                 and row.get("rating") is not None
             ):
                 rows.append({"text": text, "rating": float(row["rating"])})
-            if len(rows) >= STREAM_WINDOW:
+            if len(rows) >= stream_window:
                 break
 
-        picked = rng.choice(len(rows), size=N_PER_CATEGORY, replace=False)
+        picked = rng.choice(len(rows), size=n_per_category, replace=False)
         cat_df = pd.DataFrame([rows[i] for i in picked])
         cat_df["product_category"] = category
         parts.append(cat_df)
@@ -103,16 +107,39 @@ def load_reviews(seed: int) -> pd.DataFrame:
 
 
 def embed_documents(texts: list[str]) -> np.ndarray:
-    """Embed documents via Cohere embed-v4.0, batched."""
+    """Embed documents. **Swap this function if you don't use Cohere.**
+
+    Typologist doesn't care which embedder produced its inputs. The only
+    contract is: take ``list[str]`` of length n, return ``np.ndarray`` of
+    shape ``(n, d)`` with floating-point dtype. The default below uses
+    Cohere embed-v4.0 (1536-dim) and reads ``CO_API_KEY`` from the env.
+
+    Two common alternatives you can paste in to replace this function:
+
+        # Sentence-Transformers (local, free, 768-dim):
+        from sentence_transformers import SentenceTransformer
+        def embed_documents(texts):
+            model = SentenceTransformer("all-mpnet-base-v2")
+            return model.encode(texts, convert_to_numpy=True, show_progress_bar=True)
+
+        # OpenAI (remote, paid, 1536-dim):
+        import openai
+        def embed_documents(texts):
+            client = openai.OpenAI()
+            resp = client.embeddings.create(model="text-embedding-3-small", input=texts)
+            return np.array([d.embedding for d in resp.data], dtype=np.float32)
+    """
     import cohere
+
+    cohere_model = "embed-v4.0"
+    cohere_batch = 96
 
     client = cohere.ClientV2(api_key=os.environ["CO_API_KEY"])
     parts: list[np.ndarray] = []
-    for i in range(0, len(texts), COHERE_BATCH):
-        batch = texts[i : i + COHERE_BATCH]
+    for i in range(0, len(texts), cohere_batch):
         resp = client.embed(
-            texts=batch,
-            model=COHERE_MODEL,
+            texts=texts[i : i + cohere_batch],
+            model=cohere_model,
             input_type="search_document",
             embedding_types=["float"],
         )
@@ -188,15 +215,27 @@ def main() -> None:
 
     from typologist import Typologist
 
-    print("Loading Amazon reviews from HuggingFace...")
+    # === Step 1: load a sample corpus ===
+    print("Step 1: loading Amazon reviews from HuggingFace...")
     df = load_reviews(seed=RANDOM_SEED)
     print(f"  loaded {len(df)} reviews across {df['product_category'].nunique()} categories\n")
 
-    print("Embedding with Cohere embed-v4.0...")
+    # === Step 2: embed ===
+    print("Step 2: embedding with Cohere embed-v4.0...")
     embeddings = embed_documents(df["text"].tolist())
     print(f"  embeddings shape: {embeddings.shape}\n")
 
-    print("Fitting Typologist (n_facets=3)...")
+    # === Step 3: run Typologist ==============================================
+    # This is the part the example is actually demonstrating. Everything else
+    # in this file is plumbing. Typologist takes the documents and their
+    # embeddings, discovers n_facets categorical axes, and assigns each
+    # document a value on each axis.
+    #
+    # naming_llm, schema_llm, and labeling_llm default to Anthropic model
+    # strings (so ANTHROPIC_API_KEY is read from the env). If you use a
+    # different provider, pass a callable(prompt: str) -> str to any of those
+    # three kwargs; see docs/design.md for the full contract.
+    print("Step 3: fitting Typologist (n_facets=3)...")
     t = Typologist(
         n_facets=3,
         topic_embedder=SentenceTransformer("all-MiniLM-L6-v2"),
@@ -205,7 +244,9 @@ def main() -> None:
         random_state=RANDOM_SEED,
         verbose=True,
     ).fit(df["text"], embeddings)
+    # =========================================================================
 
+    # === Step 4: print the output ===
     print("\n=== Discovered schema ===")
     for i, facet in enumerate(t.schema_):
         print(f"\nFacet {i}: {facet['name']} ({facet['type']})")
@@ -222,7 +263,8 @@ def main() -> None:
     crosstab = pd.crosstab(labels["curator_category"], labels[primary_facet])
     print(crosstab.to_string())
 
-    print("\nRendering interactive map...")
+    # === Step 5: render the map ===
+    print("\nStep 5: rendering interactive map...")
     labels_for_map = t.labels_df_.reset_index(drop=True)
     hover = _build_hover_text(df["text"].tolist(), labels_for_map)
     render_map(

--- a/examples/amazon_reviews.py
+++ b/examples/amazon_reviews.py
@@ -4,14 +4,17 @@ What this does:
 1. Streams a stratified sample of ~500 Amazon reviews across 6 product
    categories from HuggingFace.
 2. Embeds the reviews with Cohere embed-v4.0.
-3. Runs Typologist to discover 3 categorical facets.
+3. Runs Typologist to discover 3 categorical facets (the main event).
 4. Prints the discovered schema and a crosstab of facet 0 against the
    curator-assigned product category (to show the rediscovery effect).
-5. Renders an interactive DataMapPlot HTML you can open in a browser,
-   colored by each discovered facet (toggle between layers).
+5. Renders an interactive DataMapPlot HTML that combines:
+   - region text labels from a separate Toponymy fit on the 2D UMAP coords
+     (spatial cluster names at fine-to-coarse granularity), and
+   - point colors switchable between Typologist's facets via a dropdown.
 
-Expected runtime: ~5 minutes on a laptop.
-Expected cost: ~$3 (Cohere embedding + Anthropic Haiku labeling + Opus synthesis).
+Expected runtime: ~6 minutes on a laptop.
+Expected cost: ~$3 (Cohere embedding + Anthropic LLM calls for schema
+synthesis, per-doc labeling, and topic naming).
 
 Required environment variables:
     CO_API_KEY         Cohere API key, for embeddings
@@ -119,22 +122,32 @@ def embed_documents(texts: list[str]) -> np.ndarray:
 
 
 def render_map(
+    documents: list[str],
     embeddings: np.ndarray,
     labels_df: pd.DataFrame,
+    topic_embedder,
     hover_text: list[str],
     output_path: Path,
     seed: int,
+    verbose: bool = True,
 ) -> None:
-    """Run UMAP on the embeddings and render an interactive DataMapPlot.
+    """Render an interactive DataMapPlot that pairs two separately-produced
+    structures over the same corpus:
 
-    Each Typologist-discovered facet becomes one selectable colormap in the
-    ``colormaps=`` dict; a dropdown in the plot lets the viewer switch point
-    coloring between facets. Region text annotations (``*label_layers``) are
-    deliberately left off: the correct source for those is Toponymy fit on
-    the 2D coords, which is outside the scope of this example.
+    - Point colors come from Typologist's facets (one selectable colormap per
+      facet; a dropdown in the UI switches between them).
+    - Region text annotations come from a separate Toponymy fit on the 2D
+      UMAP coords (fine-to-coarse cluster-name hierarchy). This is the right
+      division of labor: Typologist's facets are categorical metadata about
+      each point, whereas the plot's region labels are spatial cluster names
+      that depend on the 2D layout, so they need to be computed from the 2D
+      coords directly.
     """
     import datamapplot
     import umap
+    from toponymy import Toponymy
+    from toponymy.clustering import KMeansClusterer
+    from toponymy.llm_wrappers import AnthropicNamer
 
     print("  projecting to 2D with UMAP...", flush=True)
     coords = umap.UMAP(
@@ -144,14 +157,37 @@ def render_map(
         random_state=seed,
     ).fit_transform(embeddings)
 
+    print("  naming 2D clusters via Toponymy...", flush=True)
+    namer = AnthropicNamer(
+        api_key=os.environ["ANTHROPIC_API_KEY"],
+        model="claude-haiku-4-5-20251001",
+    )
+    topo = Toponymy(
+        llm_wrapper=namer,
+        text_embedding_model=topic_embedder,
+        # KMeans here rather than ToponymyClusterer because the version pair
+        # (toponymy 0.5.x + current fast_hdbscan) has a boruvka signature
+        # drift that ToponymyClusterer hits; KMeans is simpler and adequate
+        # for spatial region labels on a 2D map.
+        clusterer=KMeansClusterer(min_clusters=5, base_n_clusters=20),
+        object_description="product reviews",
+        corpus_description="Amazon product reviews",
+        verbose=verbose,
+    )
+    # fit(objects, embedding_vectors, clusterable_vectors): high-dim used for
+    # keyphrase generation, 2D used for the clustering that drives plot labels.
+    topo.fit(documents, embeddings, coords)
+    label_layers = [layer.make_topic_name_vector() for layer in topo.cluster_layers_]
+
     colormaps = {col: labels_df[col].astype(str).to_numpy() for col in labels_df.columns}
 
     fig = datamapplot.create_interactive_plot(
         coords,
+        *label_layers,
         colormaps=colormaps,
         hover_text=hover_text,
         title="Amazon reviews",
-        sub_title="Point colors switchable between Typologist-discovered facets.",
+        sub_title="Region labels from Toponymy; point colors switchable between Typologist facets.",
         inline_data=True,
     )
     fig.save(str(output_path))
@@ -173,10 +209,15 @@ def main() -> None:
     embeddings = embed_documents(df["text"].tolist())
     print(f"  embeddings shape: {embeddings.shape}\n")
 
+    # One SentenceTransformer instance shared between Typologist (for its
+    # internal keyphrase/topic-name embedding) and the Toponymy-on-2D run
+    # inside render_map.
+    topic_embedder = SentenceTransformer("all-MiniLM-L6-v2")
+
     print("Fitting Typologist (n_facets=3)...")
     t = Typologist(
         n_facets=3,
-        topic_embedder=SentenceTransformer("all-MiniLM-L6-v2"),
+        topic_embedder=topic_embedder,
         object_description="product reviews",
         corpus_description="Amazon product reviews",
         random_state=RANDOM_SEED,
@@ -200,10 +241,12 @@ def main() -> None:
     print(crosstab.to_string())
 
     print("\nRendering interactive map...")
-    hover = [t[:200] for t in df["text"].tolist()]
+    hover = [doc[:200] for doc in df["text"].tolist()]
     render_map(
+        documents=df["text"].tolist(),
         embeddings=embeddings,
         labels_df=t.labels_df_.reset_index(drop=True),
+        topic_embedder=topic_embedder,
         hover_text=hover,
         output_path=HTML_OUTPUT,
         seed=RANDOM_SEED,
@@ -225,39 +268,43 @@ if __name__ == "__main__":
 # === Discovered schema ===
 #
 # Facet 0: product_category (categorical)
-#   The broad Amazon product category that the review pertains to.
-#   - electronics_and_tech
+#   The broad product category that the Amazon review is describing.
 #   - books
-#   - apparel_and_footwear
-#   - beauty_and_personal_care
-#   - toys_and_games
-#   - kitchen_and_home
-#   - bags_and_accessories
+#   - toys
+#   - electronics
+#   - kitchen
+#   - apparel
+#   - footwear
+#   - personal_care
+#   - hair_accessories
 #   - Other
 #
 # Facet 1: review_sentiment (categorical)
-#   The overall sentiment and evaluative tone the reviewer expresses about
-#   the product.
+#   The overall sentiment and satisfaction level the reviewer expresses
+#   toward the product.
 #   - highly_positive
-#   - mixed_with_caveats
-#   - disappointed_negative
-#   - neutral_informational
+#   - mostly_positive
+#   - mixed
+#   - mostly_negative
+#   - highly_negative
 #   - Other
 #
-# Facet 2: intended_user (categorical)
-#   Who the reviewer indicates the product was purchased for or used by.
-#   - self
-#   - child
-#   - spouse_or_partner
-#   - parent_or_elderly_relative
-#   - friend_as_gift
-#   - household_shared
+# Facet 2: review_focus_aspect (categorical)
+#   The primary product attribute or dimension the reviewer focuses their
+#   evaluation on.
+#   - physical_quality_and_durability
+#   - fit_and_sizing
+#   - appearance_and_aesthetics
+#   - functional_performance
+#   - value_for_price
+#   - customer_service_experience
+#   - ease_of_use_and_instructions
 #   - Other
 #
 # Facet 0's crosstab against Amazon's own product_category shows heavy
-# diagonal concentration: Typologist rediscovers the curators' categorization
-# from the text alone, and sometimes refines it (Amazon's
-# Clothing_Shoes_and_Jewelry splits into apparel_and_footwear + bags_and_
-# accessories; Electronics spills a bit into bags_and_accessories for tech
-# accessories/cases). Facets 1 and 2 add orthogonal axes that
-# product_category alone doesn't capture.
+# diagonal concentration and meaningful refinement: Typologist splits
+# Clothing_Shoes_and_Jewelry into apparel + footwear + hair_accessories, and
+# All_Beauty into personal_care + hair_accessories. That's arguably a
+# cleaner taxonomy than the original six-way split. Facets 1 and 2 add
+# sentiment and evaluation-focus axes that product_category alone doesn't
+# capture.

--- a/examples/amazon_reviews.py
+++ b/examples/amazon_reviews.py
@@ -1,0 +1,263 @@
+"""Discover categorical facets in a sample of Amazon product reviews.
+
+What this does:
+1. Streams a stratified sample of ~500 Amazon reviews across 6 product
+   categories from HuggingFace.
+2. Embeds the reviews with Cohere embed-v4.0.
+3. Runs Typologist to discover 3 categorical facets.
+4. Prints the discovered schema and a crosstab of facet 0 against the
+   curator-assigned product category (to show the rediscovery effect).
+5. Renders an interactive DataMapPlot HTML you can open in a browser,
+   colored by each discovered facet (toggle between layers).
+
+Expected runtime: ~5 minutes on a laptop.
+Expected cost: ~$3 (Cohere embedding + Anthropic Haiku labeling + Opus synthesis).
+
+Required environment variables:
+    CO_API_KEY         Cohere API key, for embeddings
+    ANTHROPIC_API_KEY  Anthropic API key, for the three LLM roles
+
+Required extra installs (on top of `typologist` itself):
+    uv pip install datasets sentence-transformers cohere umap-learn datamapplot
+
+Run from the repo root:
+    uv run python examples/amazon_reviews.py
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+# --- configuration ----------------------------------------------------------
+
+CATEGORIES = [
+    "Books",
+    "Electronics",
+    "All_Beauty",
+    "Clothing_Shoes_and_Jewelry",
+    "Home_and_Kitchen",
+    "Toys_and_Games",
+]
+N_PER_CATEGORY = 83  # 6 x 83 = 498 reviews total
+STREAM_WINDOW = 3000
+MIN_TEXT_CHARS = 200
+RANDOM_SEED = 0
+
+COHERE_MODEL = "embed-v4.0"
+COHERE_BATCH = 96
+
+OUTPUT_DIR = Path(__file__).parent
+HTML_OUTPUT = OUTPUT_DIR / "amazon_reviews_map.html"
+
+_AMAZON_JSONL_URL = (
+    "https://huggingface.co/datasets/McAuley-Lab/Amazon-Reviews-2023"
+    "/resolve/main/raw/review_categories/{category}.jsonl"
+)
+
+
+# --- helpers ----------------------------------------------------------------
+
+
+def load_reviews(seed: int) -> pd.DataFrame:
+    """Stream a stratified sample of Amazon reviews from HuggingFace.
+
+    For each category, streams the first STREAM_WINDOW rows from the public
+    JSONL dump, filters to verified purchases with text >= MIN_TEXT_CHARS,
+    and samples N_PER_CATEGORY rows. Returns a DataFrame with columns:
+    text, rating, product_category.
+    """
+    from datasets import load_dataset
+
+    rng = np.random.default_rng(seed)
+    parts: list[pd.DataFrame] = []
+
+    for category in CATEGORIES:
+        print(f"  streaming {category}...", flush=True)
+        url = _AMAZON_JSONL_URL.format(category=category)
+        ds = load_dataset("json", data_files=url, split="train", streaming=True)
+
+        rows: list[dict] = []
+        for row in ds:
+            text = row.get("text") or ""
+            if (
+                row.get("verified_purchase")
+                and len(text) >= MIN_TEXT_CHARS
+                and row.get("rating") is not None
+            ):
+                rows.append({"text": text, "rating": float(row["rating"])})
+            if len(rows) >= STREAM_WINDOW:
+                break
+
+        picked = rng.choice(len(rows), size=N_PER_CATEGORY, replace=False)
+        cat_df = pd.DataFrame([rows[i] for i in picked])
+        cat_df["product_category"] = category
+        parts.append(cat_df)
+
+    return pd.concat(parts, ignore_index=True)
+
+
+def embed_documents(texts: list[str]) -> np.ndarray:
+    """Embed documents via Cohere embed-v4.0, batched."""
+    import cohere
+
+    client = cohere.ClientV2(api_key=os.environ["CO_API_KEY"])
+    parts: list[np.ndarray] = []
+    for i in range(0, len(texts), COHERE_BATCH):
+        batch = texts[i : i + COHERE_BATCH]
+        resp = client.embed(
+            texts=batch,
+            model=COHERE_MODEL,
+            input_type="search_document",
+            embedding_types=["float"],
+        )
+        parts.append(np.array(resp.embeddings.float_, dtype=np.float32))
+    return np.vstack(parts)
+
+
+def render_map(
+    embeddings: np.ndarray,
+    labels_df: pd.DataFrame,
+    hover_text: list[str],
+    output_path: Path,
+    seed: int,
+) -> None:
+    """Run UMAP on the embeddings and render a multi-layer DataMapPlot.
+
+    Each facet in ``labels_df`` becomes a separate label layer in the
+    interactive plot, so the viewer can switch between colorings.
+    """
+    import datamapplot
+    import umap
+
+    print("  projecting to 2D with UMAP...", flush=True)
+    coords = umap.UMAP(
+        n_neighbors=15,
+        min_dist=0.1,
+        n_components=2,
+        random_state=seed,
+    ).fit_transform(embeddings)
+
+    # Each column of labels_df (one per discovered facet) becomes one
+    # positional *label_layers argument to create_interactive_plot.
+    label_layers = [labels_df[col].astype(str).to_numpy() for col in labels_df.columns]
+
+    fig = datamapplot.create_interactive_plot(
+        coords,
+        *label_layers,
+        hover_text=hover_text,
+        title="Amazon reviews, colored by Typologist-discovered facets",
+        sub_title="Toggle layers to switch between facets.",
+        inline_data=True,
+    )
+    fig.save(str(output_path))
+
+
+# --- main -------------------------------------------------------------------
+
+
+def main() -> None:
+    from sentence_transformers import SentenceTransformer
+
+    from typologist import Typologist
+
+    print("Loading Amazon reviews from HuggingFace...")
+    df = load_reviews(seed=RANDOM_SEED)
+    print(f"  loaded {len(df)} reviews across {df['product_category'].nunique()} categories\n")
+
+    print("Embedding with Cohere embed-v4.0...")
+    embeddings = embed_documents(df["text"].tolist())
+    print(f"  embeddings shape: {embeddings.shape}\n")
+
+    print("Fitting Typologist (n_facets=3)...")
+    t = Typologist(
+        n_facets=3,
+        topic_embedder=SentenceTransformer("all-MiniLM-L6-v2"),
+        object_description="product reviews",
+        corpus_description="Amazon product reviews",
+        random_state=RANDOM_SEED,
+        verbose=True,
+    ).fit(df["text"], embeddings)
+
+    print("\n=== Discovered schema ===")
+    for i, facet in enumerate(t.schema_):
+        print(f"\nFacet {i}: {facet['name']} ({facet['type']})")
+        print(f"  {facet['definition']}")
+        for value in facet["values"]:
+            print(f"  - {value}")
+
+    primary_facet = t.schema_[0]["name"]
+    print(f"\n=== Facet 0 ({primary_facet}) vs curator-assigned product category ===\n")
+    # Use a distinct column name so a facet named "product_category" doesn't
+    # collide with the curator column when we join them.
+    labels = t.labels_df_.reset_index(drop=True)
+    labels["curator_category"] = df["product_category"].values
+    crosstab = pd.crosstab(labels["curator_category"], labels[primary_facet])
+    print(crosstab.to_string())
+
+    print("\nRendering interactive map...")
+    hover = [t[:200] for t in df["text"].tolist()]
+    render_map(
+        embeddings=embeddings,
+        labels_df=t.labels_df_.reset_index(drop=True),
+        hover_text=hover,
+        output_path=HTML_OUTPUT,
+        seed=RANDOM_SEED,
+    )
+    print(f"  saved {HTML_OUTPUT.relative_to(Path.cwd())}")
+    print(f"  open in a browser: file://{HTML_OUTPUT}")
+
+
+if __name__ == "__main__":
+    main()
+
+
+# Sample output from a run on 2026-04-22 with seed=0 (exact wording varies
+# seed-to-seed because EVoC clustering is non-deterministic):
+#
+# === Discovered schema ===
+#
+# Facet 0: product_category (categorical)
+#   The category of product being reviewed, based on the item's primary use
+#   and market segment.
+#   - apparel_and_footwear
+#   - books_and_cookbooks
+#   - bags_and_luggage
+#   - electronics_and_accessories
+#   - kitchen_tools
+#   - beauty_and_personal_care
+#   - toys_and_plush
+#   - Other
+#
+# Facet 1: review_sentiment (categorical)
+#   The overall sentiment the reviewer expresses toward the product, ranging
+#   from enthusiastic praise to strong dissatisfaction.
+#   - strongly_positive
+#   - mildly_positive
+#   - mixed
+#   - mildly_negative
+#   - strongly_negative
+#   - Other
+#
+# Facet 2: review_focus_aspect (categorical)
+#   The primary product attribute the reviewer emphasizes when evaluating
+#   the item.
+#   - fit_and_sizing
+#   - durability_and_longevity
+#   - ease_of_use
+#   - value_for_money
+#   - aesthetic_appearance
+#   - performance_effectiveness
+#   - comfort_and_feel
+#   - instructions_and_setup
+#   - Other
+#
+# Facet 0's crosstab against Amazon's own product_category shows heavy
+# diagonal concentration: Typologist rediscovers the curators' categorization
+# from the text alone, sometimes refining it further (Amazon's
+# Clothing_Shoes_and_Jewelry splits into apparel_and_footwear and
+# bags_and_luggage in the discovered schema). Facets 1 and 2 add orthogonal
+# axes that product_category alone doesn't capture.

--- a/examples/amazon_reviews.py
+++ b/examples/amazon_reviews.py
@@ -7,14 +7,13 @@ What this does:
 3. Runs Typologist to discover 3 categorical facets (the main event).
 4. Prints the discovered schema and a crosstab of facet 0 against the
    curator-assigned product category (to show the rediscovery effect).
-5. Renders an interactive DataMapPlot HTML that combines:
-   - region text labels from a separate Toponymy fit on the 2D UMAP coords
-     (spatial cluster names at fine-to-coarse granularity), and
-   - point colors switchable between Typologist's facets via a dropdown.
+5. Renders an interactive DataMapPlot HTML: point colors switch between
+   Typologist facets via a dropdown; hovering on a point shows the
+   assigned facet values followed by the review text itself.
 
-Expected runtime: ~6 minutes on a laptop.
+Expected runtime: ~5 minutes on a laptop.
 Expected cost: ~$3 (Cohere embedding + Anthropic LLM calls for schema
-synthesis, per-doc labeling, and topic naming).
+synthesis and per-doc labeling).
 
 Required environment variables:
     CO_API_KEY         Cohere API key, for embeddings
@@ -121,33 +120,44 @@ def embed_documents(texts: list[str]) -> np.ndarray:
     return np.vstack(parts)
 
 
+def _build_hover_text(
+    texts: list[str],
+    labels_df: pd.DataFrame,
+    max_text_chars: int = 500,
+) -> list[str]:
+    """Per-point tooltip: Typologist facet values, then the (truncated) text.
+
+    Labels go first so readers see Typologist's output on hover at a glance;
+    the review text follows in case they want to check the labels against
+    the source.
+    """
+    hovers: list[str] = []
+    for i, raw in enumerate(texts):
+        parts = [f"{col}: {labels_df[col].iloc[i]}" for col in labels_df.columns]
+        text = raw if len(raw) <= max_text_chars else raw[:max_text_chars] + "..."
+        hovers.append("\n".join(parts) + "\n\n" + text)
+    return hovers
+
+
 def render_map(
-    documents: list[str],
     embeddings: np.ndarray,
     labels_df: pd.DataFrame,
-    topic_embedder,
     hover_text: list[str],
     output_path: Path,
     seed: int,
-    verbose: bool = True,
 ) -> None:
-    """Render an interactive DataMapPlot that pairs two separately-produced
-    structures over the same corpus:
+    """Render an interactive DataMapPlot of the corpus.
 
-    - Point colors come from Typologist's facets (one selectable colormap per
-      facet; a dropdown in the UI switches between them).
-    - Region text annotations come from a separate Toponymy fit on the 2D
-      UMAP coords (fine-to-coarse cluster-name hierarchy). This is the right
-      division of labor: Typologist's facets are categorical metadata about
-      each point, whereas the plot's region labels are spatial cluster names
-      that depend on the 2D layout, so they need to be computed from the 2D
-      coords directly.
+    Each Typologist-discovered facet becomes one selectable colormap in the
+    ``colormaps=`` dict; a dropdown in the plot lets the viewer switch point
+    coloring between facets. Region text annotations (``*label_layers``) are
+    deliberately left off: the right source for those is Toponymy fit on the
+    2D coords, which is its own can of worms (picks a clusterer, manages
+    upstream compat, another ~$0.25 and a minute of runtime) and risks
+    implying the region labels are Typologist output when they are not.
     """
     import datamapplot
     import umap
-    from toponymy import Toponymy
-    from toponymy.clustering import KMeansClusterer
-    from toponymy.llm_wrappers import AnthropicNamer
 
     print("  projecting to 2D with UMAP...", flush=True)
     coords = umap.UMAP(
@@ -157,41 +167,14 @@ def render_map(
         random_state=seed,
     ).fit_transform(embeddings)
 
-    print("  naming 2D clusters via Toponymy...", flush=True)
-    namer = AnthropicNamer(
-        api_key=os.environ["ANTHROPIC_API_KEY"],
-        model="claude-haiku-4-5-20251001",
-    )
-    topo = Toponymy(
-        llm_wrapper=namer,
-        text_embedding_model=topic_embedder,
-        # KMeans here rather than ToponymyClusterer because the version pair
-        # (toponymy 0.5.x + current fast_hdbscan) has a boruvka signature
-        # drift that ToponymyClusterer hits. Tracked upstream at
-        # TutteInstitute/toponymy#135 and in our own #4. KMeans is the demo
-        # clusterer (not Toponymy's recommended choice) and its layers are
-        # independent KMeans runs stitched into a tree post-hoc rather than
-        # a true density hierarchy, but it's adequate for 2D region labels
-        # here.
-        clusterer=KMeansClusterer(min_clusters=5, base_n_clusters=20),
-        object_description="product reviews",
-        corpus_description="Amazon product reviews",
-        verbose=verbose,
-    )
-    # fit(objects, embedding_vectors, clusterable_vectors): high-dim used for
-    # keyphrase generation, 2D used for the clustering that drives plot labels.
-    topo.fit(documents, embeddings, coords)
-    label_layers = [layer.make_topic_name_vector() for layer in topo.cluster_layers_]
-
     colormaps = {col: labels_df[col].astype(str).to_numpy() for col in labels_df.columns}
 
     fig = datamapplot.create_interactive_plot(
         coords,
-        *label_layers,
         colormaps=colormaps,
         hover_text=hover_text,
         title="Amazon reviews",
-        sub_title="Region labels from Toponymy; point colors switchable between Typologist facets.",
+        sub_title="Point colors switchable between Typologist-discovered facets.",
         inline_data=True,
     )
     fig.save(str(output_path))
@@ -213,15 +196,10 @@ def main() -> None:
     embeddings = embed_documents(df["text"].tolist())
     print(f"  embeddings shape: {embeddings.shape}\n")
 
-    # One SentenceTransformer instance shared between Typologist (for its
-    # internal keyphrase/topic-name embedding) and the Toponymy-on-2D run
-    # inside render_map.
-    topic_embedder = SentenceTransformer("all-MiniLM-L6-v2")
-
     print("Fitting Typologist (n_facets=3)...")
     t = Typologist(
         n_facets=3,
-        topic_embedder=topic_embedder,
+        topic_embedder=SentenceTransformer("all-MiniLM-L6-v2"),
         object_description="product reviews",
         corpus_description="Amazon product reviews",
         random_state=RANDOM_SEED,
@@ -245,12 +223,11 @@ def main() -> None:
     print(crosstab.to_string())
 
     print("\nRendering interactive map...")
-    hover = [doc if len(doc) <= 500 else doc[:500] + "..." for doc in df["text"].tolist()]
+    labels_for_map = t.labels_df_.reset_index(drop=True)
+    hover = _build_hover_text(df["text"].tolist(), labels_for_map)
     render_map(
-        documents=df["text"].tolist(),
         embeddings=embeddings,
-        labels_df=t.labels_df_.reset_index(drop=True),
-        topic_embedder=topic_embedder,
+        labels_df=labels_for_map,
         hover_text=hover,
         output_path=HTML_OUTPUT,
         seed=RANDOM_SEED,


### PR DESCRIPTION
## Summary

Adds `examples/amazon_reviews.py`: a single runnable script that loads ~500 Amazon reviews from HuggingFace, embeds them with Cohere, runs Typologist, and renders an interactive DataMapPlot HTML.

## What it shows

- **Rediscovery:** Typologist finds `product_category` from the text alone, sometimes refining beyond the curator's original categorization (e.g. splits Amazon's `Clothing_Shoes_and_Jewelry` into `apparel_and_footwear` + `bags_and_luggage`).
- **Novel structure:** `review_sentiment` (strongly_positive -> strongly_negative) and `review_focus_aspect` (fit, durability, value, etc.) are orthogonal axes the curator metadata doesn't capture.
- **Interactive output:** multi-layer DataMapPlot colored by each discovered facet, saved as a single self-contained HTML file.

## Choices worth flagging

- **Dataset loader copied into `examples/`, not promoted to a `typologist.datasets` module.** The loader is ~35 lines and self-contained; promoting it is its own design decision (which datasets to support, optional-extras handling, API shape) and should be a separate PR closer to when we're preparing to promote the project.
- **`datamapplot` and `umap-learn` are not added to `pyproject.toml`.** They're documented as required extras in the script's docstring (`uv pip install ...`). Keeps the base install lean; the `typologist[viz]` extra that `docs/design.md` parks for 0.2 would subsume these later.
- **No metadata erasure in the example.** Erase mode has the sentiment-rediscovery caveat we documented in `docs/design.md`, which is better suited to a design doc than a first example. The `no_erase` story is cleaner: "Typologist rediscovers what you know and adds axes you didn't."
- **Generated HTML is gitignored.** Regenerated on each run; the script carries a trailing comment block with a sample schema so readers can see what to expect without running it.

## Test plan

- [x] Runs end-to-end against public data in ~5 min for ~$3 (verified on 2026-04-22 with seed=0)
- [x] Produces a non-empty HTML file (~212 KB) that opens correctly in a browser
- [x] Discovered schema matches the expected three-facet shape documented in the trailing comment block
- [x] Crosstab of facet 0 against the curator's `product_category` shows the rediscovery pattern