### PR TITLE
docs: add terminology glossary and architecture section

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,10 @@ Alpha. 0.0.1 is live on PyPI; the public API is still subject to change as we it
 - Name casing: `typologist` in code, imports, CLI, PyPI; `Typologist` in prose, class names, README titles.
 - Support commitments: respond to issues within a week, tagged PyPI releases, semver discipline, maintained CHANGELOG.
 
+## Terminology
+
+@docs/glossary.md
+
 ## Inherited gotchas from the dependency ecosystem
 
 These apply to any code built on Toponymy + EVoC + LEACE, carried over from prior work on the predecessor harness:

--- a/docs/design.md
+++ b/docs/design.md
@@ -14,6 +14,18 @@ This document is the public-API contract the 0.1 implementation works against. I
 
 **Out of scope for 0.1.** See "Parking lot" at the end.
 
+## Architecture
+
+Typologist's architectural shape is a deliberate commitment that shows up in nearly every API decision: the LLM is used only at the leaves of the pipeline as a stateless function, while all integration across the corpus happens in a geometric substrate.
+
+**LLM calls are small, local, and stateless.** There are exactly three LLM roles (`naming_llm`, `schema_llm`, `labeling_llm`), and each call operates on a narrow input: one cluster to name, one set of cluster names to synthesize a facet from, one document to label on one facet. No call sees the full corpus. No call holds memory of other calls. Each is a parallelizable, cacheable, retryable function invocation.
+
+**Integration happens in the geometric substrate.** The embedding space (via similarity, clustering, and LEACE projections), the topic hierarchy (via Toponymy), and the structural operations on them (nearest-neighbor graphs, facility-location sampling, concept erasure) are where documents are woven into a coherent typology. This layer does not reason; it operates on shape.
+
+This split produces corpus-level exchangeability: the pipeline is approximately order-invariant across documents, so every document gets equal weight on the emergent typology rather than being read through the lens of whatever came before it in an LLM's context. The inductive bias is the same one that justifies bag-of-words models, de Finetti exchangeability, and hierarchical Bayes: given a population of cases, treat them as order-invariant when you're trying to recover latent structure.
+
+The commitment is intentional. Agentic architectures are useful for path-dependent problems (planning, search, long-form summarization); typology extraction is not that kind of problem. The cost is correctly priced: Typologist cannot exploit long-range correlations between documents, which is the right trade-off for building orthogonal category systems but a fatal one for, say, summarizing a novel.
+
 ## Public surface
 
 ```python

--- a/docs/design.md
+++ b/docs/design.md
@@ -20,7 +20,7 @@ Typologist's architectural shape is a deliberate commitment that shows up in nea
 
 **LLM calls are small, local, and stateless.** There are exactly three LLM roles (`naming_llm`, `schema_llm`, `labeling_llm`), and each call operates on a narrow input: one cluster to name, one set of cluster names to synthesize a facet from, one document to label on one facet. No call sees the full corpus. No call holds memory of other calls. Each is a parallelizable, cacheable, retryable function invocation.
 
-**Integration happens in the geometric substrate.** The embedding space (via similarity, clustering, and LEACE projections), the topic hierarchy (via Toponymy), and the structural operations on them (nearest-neighbor graphs, facility-location sampling, concept erasure) are where documents are woven into a coherent typology. This layer does not reason; it operates on shape.
+**Integration happens in the geometric substrate.** The embedding space (via similarity, EVoC clustering, and LEACE projections), the topic hierarchy (via Toponymy), and the structural operations on them (nearest-neighbor graphs, facility-location sampling, concept erasure) are where documents are woven into a coherent typology. This layer does not reason; it operates on shape.
 
 This split produces corpus-level exchangeability: the pipeline is approximately order-invariant across documents, so every document gets equal weight on the emergent typology rather than being read through the lens of whatever came before it in an LLM's context. The inductive bias is the same one that justifies bag-of-words models, de Finetti exchangeability, and hierarchical Bayes: given a population of cases, treat them as order-invariant when you're trying to recover latent structure.
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,42 @@
+# Glossary
+
+This document locks the project's terminology. It governs code identifiers, variable names, docstrings, prompt text, and user-facing prose. CLAUDE.md imports this file via `@docs/glossary.md`, so the canonical terms below are always in context when Claude is assisting on this repository.
+
+The core shape: a *corpus* of *documents* (plus their *embeddings*, and optionally *metadata* to erase) goes in; a *schema* comes out. A schema is a list of *facets*. Each facet has *values*. Each document gets a *label* on each facet (the value it was assigned).
+
+## Canonical terms
+
+### Input side
+
+- **corpus**: the full collection of input documents.
+- **document**: one input string. Prefer "document" over "doc" or "item" in public API and docs; "doc" is acceptable in internal variable names for brevity.
+- **embedding**: a vector representation of a document. Always positionally row-aligned with the documents; never index-joined.
+- **metadata**: a DataFrame of user-supplied columns to concept-erase before discovery. Passing this is the sole signal of intent to erase.
+
+### Output side
+
+- **schema**: the full discovered output, an ordered list of facets. Stored on the fitted `Typologist` as `schema_`. JSON-serializable.
+- **facet**: one categorical axis in the schema. Has a name, a kind, a vocabulary of values, and a definition. A discovered facet is one entry of `schema_`.
+- **kind**: the shape of a facet. In 0.1, always `categorical`; `ordinal` is planned for 0.2+.
+- **value**: one element of a facet's vocabulary, for example `highly_positive`. Distinct from a label: a value is a vocabulary entry, a label is a specific document's assignment.
+- **label**: the value a document has been assigned on a specific facet. `labels_df_.iloc[i, j]` is document `i`'s label on facet `j`.
+- **noise label**: the sentinel string (default `"Unlabelled"`) written into `labels_df_` when a document couldn't be classified. British spelling matches Toponymy and DataMapPlot.
+
+## Avoid, and what to use instead
+
+- **field** → facet. "Field" is SQL/DataFrame vocabulary. Reserve it for pandas column names, not our facets.
+- **category** / **categorical** as a noun for a value → value. "Categorical" is fine as an adjective describing a facet's kind; avoid it as a count noun ("the categories of this facet"). Pandas' `pd.Categorical` is a separate concept (see collisions below).
+- **dimension** / **axis** in public API, code, and user-facing prose → facet. LLM prompts are the deliberate exception (see "Prompt vocabulary" below).
+- **topic** → facet. Toponymy emits "topic names" for clusters, which are inputs to facet synthesis, not facets themselves. The parameter `topic_embedder` is named for Toponymy's use of the embedder, not because we adopt the word for our own outputs.
+- **type** for a facet's kind → kind. "Type" is too loaded in Python and pandas; reserve it for its usual senses. This applies to prose, dict keys, and variable names.
+
+## Prompt vocabulary: a deliberate exception
+
+LLM prompts (in `src/typologist/_prompts.py` and inside stored `labeling_prompt_template` strings) use "axis", "dimension", and "orthogonal" as discovery language. A user reading a stored template will see phrases like `along the "review_sentiment" dimension`. This is intentional: those words read naturally to the model as discovery instructions, and "facet" is house vocabulary the LLM doesn't benefit from being taught.
+
+Implication for future prompt edits: keep prompt text in discovery language; translate back to "facet" anywhere that text leaves the prompt (docstrings, error messages, public API names, docs).
+
+## Collisions we live with
+
+- **DataMapPlot `label_layers`.** DataMapPlot's `*label_layers` parameter means text that renders over regions of the 2D map. It is not the same thing as our `labels_df_`. Our labels feed DataMapPlot's `colormaps=` parameter (per-point categorical coloring), not `label_layers`. When writing example or integration code near DataMapPlot, qualify ("Typologist labels", "region labels") if surrounding context doesn't make the meaning unambiguous.
+- **`pd.Categorical`.** The pandas dtype used for `labels_df_` columns. Unrelated to our `categorical` facet kind. Say `pd.Categorical` or "Categorical dtype" when referring to the pandas concept; reserve bare "categorical" for the facet kind.


### PR DESCRIPTION
## Summary

- Add `docs/glossary.md` locking the canonical project terms (corpus, document, schema, facet, value, label), plus an avoid-list and collision notes for DataMapPlot's `label_layers` and `pd.Categorical`.
- Import the glossary into `CLAUDE.md` via `@docs/glossary.md` so the rules load automatically into every Claude Code session.
- Add an `## Architecture` section to `docs/design.md` articulating the deliberate split between stateless LLM use at the leaves and geometric integration across the corpus, and the exchangeability commitment that follows from it.

No code paths touched; pure docs.

## Follow-ups

Two renames will land as separate PRs after this:

1. Internal `field` → `facet` in prompts and pipeline (minor LLM-visible prompt text change).
2. Schema dict key `"type"` → `"kind"` (breaks the 0.0.1 serialized-schema shape; cheap at alpha).

## Test plan

- [x] Skim glossary for completeness against current code terms
- [ ] Confirm `@docs/glossary.md` import resolves at session start
- [x] Read Architecture section for clarity and honesty about the trade-off

🤖 Generated with [Claude Code](https://claude.com/claude-code)