### PR TITLE
refactor: rename internal "field" to "facet"

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -9,7 +9,7 @@ This document is the public-API contract the 0.1 implementation works against. I
 - A single `Typologist` class (sklearn-style, `fit`-then-attributes)
 - A top-level `apply_schema` helper for labeling new documents with a previously-discovered schema
 - LEACE pre-erasure of user-supplied known metadata
-- Between-facet LEACE residualization against per-doc classifications under synthesized schema fields (not cluster labels; matches predecessor evidence)
+- Between-facet LEACE residualization against per-doc classifications under synthesized facets (not cluster labels; matches predecessor evidence)
 - Synchronous execution only
 
 **Out of scope for 0.1.** See "Parking lot" at the end.
@@ -61,7 +61,7 @@ labels_df = apply_schema(schema, documents, llm=None)
 | `object_description` | `str` | `"objects"` | describes what each document is. Passed through to Toponymy; also rendered into our schema-synthesis and labeling prompts |
 | `corpus_description` | `str` | `"collection of objects"` | describes the collection as a whole. Same passthrough behavior |
 | `naming_llm` | `str \| Callable` | `"claude-haiku-4-5"` | names Toponymy's clusters. Called O(n_clusters x n_layers x n_facets) times |
-| `schema_llm` | `str \| Callable` | `"claude-opus-4-7"` | synthesizes a schema field from cluster names. Called O(n_facets) times; quality-dominant step |
+| `schema_llm` | `str \| Callable` | `"claude-opus-4-7"` | synthesizes a facet from cluster names. Called O(n_facets) times; quality-dominant step |
 | `labeling_llm` | `str \| Callable` | `"claude-haiku-4-5"` | classifies each document into a facet's value vocabulary. Called O(n_docs x n_facets) times |
 | `random_state` | `int \| None` | `None` | threaded into LEACE fit, sampling, NumPy RNG. EVoC has no `random_state` and is the residual source of non-determinism; this is documented, not fixed |
 | `noise_label` | `str` | `"Unlabelled"` | sentinel string for docs that couldn't be classified into any value. British spelling matches Toponymy and DataMapPlot |
@@ -186,7 +186,7 @@ Measured reductions (baseline vs with both levers, n=500 per run, 2 seeds averag
 Each item has a one-line "why deferred" note.
 
 - **Async support (0.2+).** Labeling concurrency landed early via a threadpool (see `max_concurrency` above), which delivers most of the practical throughput win without touching the `_LLM` interface. Toponymy naming and schema synthesis are still serial; full async rework with `AsyncLLMWrapper` integration is the 0.2 story.
-- **Ordinal fields (0.2+).** Predecessor evidence showed ordinal discovery works when the data has a spectrum, but the behavior was only barely observed at n=5. 0.1 emits `"categorical"` only; properly adding `"ordinal"` means prompt guidance on when to pick it, a value-ordering invariant, and `pd.Categorical(..., ordered=True)` in the labels DataFrame. Deferred until we have prompt tuning and tests that verify the ordered semantics round-trip.
+- **Ordinal facets (0.2+).** Predecessor evidence showed ordinal discovery works when the data has a spectrum, but the behavior was only barely observed at n=5. 0.1 emits `"categorical"` only; properly adding `"ordinal"` means prompt guidance on when to pick it, a value-ordering invariant, and `pd.Categorical(..., ordered=True)` in the labels DataFrame. Deferred until we have prompt tuning and tests that verify the ordered semantics round-trip.
 - **Stability helper `stability_check(docs, embeddings, n_seeds=5)` (0.2).** Predecessor evidence shows this is cheap and produces robust signal; deferred only to minimize 0.1 surface.
 - **`anthropic_llm(model)` convenience factory (0.1.x).** Collapses the 9-line `make_tracked_llm` pattern into one line; easy addition once we see real usage.
 - **Functional `discover()` (needs separate design pass).** Thin wrapper over the class didn't feel worth it given our multi-artifact output. If added later, the open design question is what a rich result object looks like so users don't miss `schema_` / `labels_df_` / `embeddings_residualized_` / `facet_diagnostics_`.

--- a/src/typologist/_pipeline.py
+++ b/src/typologist/_pipeline.py
@@ -203,7 +203,7 @@ def _run_toponymy(
     )
 
 
-_SCHEMA_FIELD_RESPONSE_SCHEMA = {
+_FACET_RESPONSE_SCHEMA = {
     "type": "object",
     "properties": {
         "name": {"type": "string"},
@@ -219,7 +219,7 @@ _SCHEMA_FIELD_RESPONSE_SCHEMA = {
 }
 
 
-def _synthesize_field(
+def _synthesize_facet(
     cluster_hierarchy: list[list[str]],
     schema_llm: _LLM,
     labeling_llm_model_name: str | None,
@@ -244,7 +244,7 @@ def _synthesize_field(
         erased_metadata_descriptions=erased_metadata_descriptions,
     )
 
-    response = schema_llm.call_structured(prompt, _SCHEMA_FIELD_RESPONSE_SCHEMA)
+    response = schema_llm.call_structured(prompt, _FACET_RESPONSE_SCHEMA)
 
     for key in ("name", "type", "values", "definition"):
         if key not in response:
@@ -269,8 +269,8 @@ def _synthesize_field(
         values.append("Other")
 
     labeling_template = render_labeling_template(
-        field_name=name,
-        field_definition=response["definition"],
+        facet_name=name,
+        facet_definition=response["definition"],
         values=values,
         object_description=object_description,
     )

--- a/src/typologist/_prompts.py
+++ b/src/typologist/_prompts.py
@@ -14,7 +14,7 @@ Respond with only valid JSON of the form:
   "name": "<lowercase snake_case identifier>",
   "type": "categorical",
   "values": ["<value1>", "<value2>", ...],
-  "definition": "<one short sentence explaining what this field captures>"
+  "definition": "<one short sentence explaining what this facet captures>"
 }}
 
 Rules:
@@ -28,9 +28,9 @@ Rules:
 """
 
 _LABELING_TEMPLATE = """\
-Classify the following {object_description} along the "{field_name}" dimension.
+Classify the following {object_description} along the "{facet_name}" dimension.
 
-{field_definition}
+{facet_definition}
 
 Choose exactly one of: {values_joined}
 
@@ -111,8 +111,8 @@ def render_synthesis_prompt(
 
 
 def render_labeling_template(
-    field_name: str,
-    field_definition: str,
+    facet_name: str,
+    facet_definition: str,
     values: list[str],
     object_description: str,
 ) -> str:
@@ -125,8 +125,8 @@ def render_labeling_template(
     values_joined = ", ".join(values)
     return _LABELING_TEMPLATE.format(
         object_description=object_description,
-        field_name=field_name,
-        field_definition=field_definition,
+        facet_name=facet_name,
+        facet_definition=facet_definition,
         values_joined=values_joined,
     )
 

--- a/src/typologist/typologist.py
+++ b/src/typologist/typologist.py
@@ -15,7 +15,7 @@ from typologist._pipeline import (
     _normalize_inputs,
     _residualize_facet,
     _run_toponymy,
-    _synthesize_field,
+    _synthesize_facet,
 )
 
 
@@ -95,7 +95,7 @@ class Typologist:
                 verbose=self.verbose,
             )
 
-            facet, synthesis_prompt = _synthesize_field(
+            facet, synthesis_prompt = _synthesize_facet(
                 cluster_hierarchy=topo.topic_names,
                 schema_llm=schema_llm,
                 labeling_llm_model_name=labeling_llm.model_name,

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -161,8 +161,8 @@ def test_synthesis_prompt_warns_against_broad_umbrella_values():
 
 def test_labeling_template_bakes_descriptions():
     template = render_labeling_template(
-        field_name="contribution_type",
-        field_definition="What the paper primarily contributes to the literature.",
+        facet_name="contribution_type",
+        facet_definition="What the paper primarily contributes to the literature.",
         values=["empirical_study", "method_paper", "theory"],
         object_description="scientific paper",
     )
@@ -174,8 +174,8 @@ def test_labeling_template_bakes_descriptions():
 
 def test_labeling_template_preserves_document_placeholder():
     template = render_labeling_template(
-        field_name="f",
-        field_definition="d",
+        facet_name="f",
+        facet_definition="d",
         values=["a", "b"],
         object_description="doc",
     )
@@ -197,8 +197,8 @@ def test_labeling_prompt_tolerates_braces_in_document():
 
 def test_labeling_template_is_self_contained_end_to_end():
     template = render_labeling_template(
-        field_name="sentiment",
-        field_definition="Overall tone.",
+        facet_name="sentiment",
+        facet_definition="Overall tone.",
         values=["positive", "negative"],
         object_description="review",
     )

--- a/tests/test_synthesis.py
+++ b/tests/test_synthesis.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pytest
 
 from typologist._llm import _LLM
-from typologist._pipeline import _synthesize_field
+from typologist._pipeline import _synthesize_facet
 
 
 class _StubSchemaLLM(_LLM):
@@ -22,7 +22,7 @@ class _StubSchemaLLM(_LLM):
         return dict(self._response)
 
 
-def test_synthesize_field_assembles_schema_entry():
+def test_synthesize_facet_assembles_schema_entry():
     schema_llm = _StubSchemaLLM(
         {
             "name": "contribution_type",
@@ -32,7 +32,7 @@ def test_synthesize_field_assembles_schema_entry():
         }
     )
 
-    facet, synthesis_prompt = _synthesize_field(
+    facet, synthesis_prompt = _synthesize_facet(
         cluster_hierarchy=[["topic_a", "topic_b"]],
         schema_llm=schema_llm,
         labeling_llm_model_name="claude-haiku-4-5",
@@ -51,7 +51,7 @@ def test_synthesize_field_assembles_schema_entry():
     assert "scientific paper" in synthesis_prompt
 
 
-def test_synthesize_field_records_callable_llm_as_none_labeling_model():
+def test_synthesize_facet_records_callable_llm_as_none_labeling_model():
     schema_llm = _StubSchemaLLM(
         {
             "name": "f",
@@ -60,7 +60,7 @@ def test_synthesize_field_records_callable_llm_as_none_labeling_model():
             "definition": "d",
         }
     )
-    facet, _ = _synthesize_field(
+    facet, _ = _synthesize_facet(
         cluster_hierarchy=[["t"]],
         schema_llm=schema_llm,
         labeling_llm_model_name=None,  # simulates callable labeling_llm
@@ -71,7 +71,7 @@ def test_synthesize_field_records_callable_llm_as_none_labeling_model():
     assert facet["labeling_model"] is None
 
 
-def test_synthesize_field_rejects_name_collision():
+def test_synthesize_facet_rejects_name_collision():
     schema_llm = _StubSchemaLLM(
         {
             "name": "contribution_type",
@@ -81,7 +81,7 @@ def test_synthesize_field_rejects_name_collision():
         }
     )
     with pytest.raises(RuntimeError, match="collides"):
-        _synthesize_field(
+        _synthesize_facet(
             cluster_hierarchy=[["t"]],
             schema_llm=schema_llm,
             labeling_llm_model_name="m",
@@ -91,7 +91,7 @@ def test_synthesize_field_rejects_name_collision():
         )
 
 
-def test_synthesize_field_rejects_duplicate_values():
+def test_synthesize_facet_rejects_duplicate_values():
     schema_llm = _StubSchemaLLM(
         {
             "name": "f",
@@ -101,7 +101,7 @@ def test_synthesize_field_rejects_duplicate_values():
         }
     )
     with pytest.raises(RuntimeError, match="duplicate values"):
-        _synthesize_field(
+        _synthesize_facet(
             cluster_hierarchy=[["t"]],
             schema_llm=schema_llm,
             labeling_llm_model_name="m",
@@ -111,7 +111,7 @@ def test_synthesize_field_rejects_duplicate_values():
         )
 
 
-def test_synthesize_field_rejects_too_few_values():
+def test_synthesize_facet_rejects_too_few_values():
     schema_llm = _StubSchemaLLM(
         {
             "name": "f",
@@ -121,7 +121,7 @@ def test_synthesize_field_rejects_too_few_values():
         }
     )
     with pytest.raises(RuntimeError, match="fewer than 2 values"):
-        _synthesize_field(
+        _synthesize_facet(
             cluster_hierarchy=[["t"]],
             schema_llm=schema_llm,
             labeling_llm_model_name="m",
@@ -131,7 +131,7 @@ def test_synthesize_field_rejects_too_few_values():
         )
 
 
-def test_synthesize_field_rejects_missing_required_field():
+def test_synthesize_facet_rejects_missing_required_field():
     schema_llm = _StubSchemaLLM(
         {
             "name": "f",
@@ -140,7 +140,7 @@ def test_synthesize_field_rejects_missing_required_field():
         }
     )
     with pytest.raises(RuntimeError, match="missing required field"):
-        _synthesize_field(
+        _synthesize_facet(
             cluster_hierarchy=[["t"]],
             schema_llm=schema_llm,
             labeling_llm_model_name="m",
@@ -150,7 +150,7 @@ def test_synthesize_field_rejects_missing_required_field():
         )
 
 
-def test_synthesize_field_appends_other_when_absent():
+def test_synthesize_facet_appends_other_when_absent():
     schema_llm = _StubSchemaLLM(
         {
             "name": "f",
@@ -159,7 +159,7 @@ def test_synthesize_field_appends_other_when_absent():
             "definition": "d",
         }
     )
-    facet, _ = _synthesize_field(
+    facet, _ = _synthesize_facet(
         cluster_hierarchy=[["t"]],
         schema_llm=schema_llm,
         labeling_llm_model_name="m",
@@ -170,7 +170,7 @@ def test_synthesize_field_appends_other_when_absent():
     assert facet["values"] == ["a", "b", "c", "Other"]
 
 
-def test_synthesize_field_dedupes_other_case_insensitively():
+def test_synthesize_facet_dedupes_other_case_insensitively():
     # If the LLM ignores instructions and includes "other", we don't double-append.
     schema_llm = _StubSchemaLLM(
         {
@@ -180,7 +180,7 @@ def test_synthesize_field_dedupes_other_case_insensitively():
             "definition": "d",
         }
     )
-    facet, _ = _synthesize_field(
+    facet, _ = _synthesize_facet(
         cluster_hierarchy=[["t"]],
         schema_llm=schema_llm,
         labeling_llm_model_name="m",
@@ -191,7 +191,7 @@ def test_synthesize_field_dedupes_other_case_insensitively():
     assert facet["values"] == ["a", "b", "other"]
 
 
-def test_synthesize_field_other_appears_in_labeling_template():
+def test_synthesize_facet_other_appears_in_labeling_template():
     schema_llm = _StubSchemaLLM(
         {
             "name": "f",
@@ -200,7 +200,7 @@ def test_synthesize_field_other_appears_in_labeling_template():
             "definition": "d",
         }
     )
-    facet, _ = _synthesize_field(
+    facet, _ = _synthesize_facet(
         cluster_hierarchy=[["t"]],
         schema_llm=schema_llm,
         labeling_llm_model_name="m",
@@ -212,7 +212,7 @@ def test_synthesize_field_other_appears_in_labeling_template():
     assert "a, b, Other" in facet["labeling_prompt_template"]
 
 
-def test_synthesize_field_passes_prior_names_to_prompt():
+def test_synthesize_facet_passes_prior_names_to_prompt():
     """Verify that prior facet names show up in the synthesis prompt the LLM sees."""
     captured_prompts: list[str] = []
 
@@ -229,7 +229,7 @@ def test_synthesize_field_passes_prior_names_to_prompt():
             "definition": "d",
         }
     )
-    _synthesize_field(
+    _synthesize_facet(
         cluster_hierarchy=[["t"]],
         schema_llm=stub,
         labeling_llm_model_name="m",


### PR DESCRIPTION
## Summary

Apply the terminology lock from [`docs/glossary.md`](docs/glossary.md): "field" is reserved for pandas column names, not facets.

**Internal renames (no public API impact):**
- `_synthesize_field` → `_synthesize_facet`
- `_SCHEMA_FIELD_RESPONSE_SCHEMA` → `_FACET_RESPONSE_SCHEMA`
- Template parameters `field_name` / `field_definition` → `facet_name` / `facet_definition`
- Test function names `test_synthesize_field_*` → `test_synthesize_facet_*`

**One LLM-visible change:** the synthesis prompt's `"<one short sentence explaining what this field captures>"` becomes `"<one short sentence explaining what this facet captures>"`. No regression expected; the word is a gloss on what the JSON `"definition"` key should hold, and "facet" reads as naturally as "field" to the model.

**No change to the labeling LLM's input.** Labeling templates use renamed `{facet_name}` / `{facet_definition}` placeholders internally, but those are substituted at synthesis time, so stored `labeling_prompt_template` strings contain no placeholders and the text the labeling LLM sees is unchanged.

Retained "field" in its legitimate dict-key senses (error message for missing JSON keys, the prompt's instruction about the `"name"` JSON field, docstrings referring to dict fields).

## Test plan

- [x] `uv run ruff check src tests` clean
- [x] `uv run ruff format --check src tests` clean
- [x] `uv run pytest` — 106 passed
- [x] Eyeball the synthesis prompt diff for the one LLM-visible wording change

🤖 Generated with [Claude Code](https://claude.com/claude-code)