### PR TITLE
refactor: rename schema "type" key to "kind"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Breaking:** renamed the `schema_[i]["type"]` dict key to `schema_[i]["kind"]`. "Type" is too loaded in Python and pandas; "kind" is the canonical term for a facet's categorical-vs-ordinal shape per `docs/glossary.md`. Saved schemas from 0.0.1 need their `"type"` key renamed to `"kind"` before loading.
 - Synthesis prompt now describes erased metadata columns to the schema LLM, so `metadata=` on `fit()` steers the LLM at both the embedding level (via LEACE) and at the prompt level. Measured reductions in curator-label rediscovery: amazon `product_category` -74%, arxiv `primary_category` -39%, amazon `rating` -8% (sentiment-like axes are harder to steer from dtype alone). See `docs/design.md` for the two-lever erasure model.
 
 ## [0.0.1] - 2026-04-22

--- a/docs/design.md
+++ b/docs/design.md
@@ -85,7 +85,7 @@ One entry per discovered facet, in discovery order:
 ```python
 {
     "name": str,                      # column name in labels_df_; must be unique across facets
-    "type": "categorical",            # 0.1 only emits categorical; ordinal is parked
+    "kind": "categorical",            # 0.1 only emits categorical; ordinal is parked
     "values": list[str],              # value vocabulary for this facet, "Other" appended
     "definition": str,                # human-readable semantic definition
     "labeling_prompt_template": str,  # f-string template containing "{document}"

--- a/examples/amazon_reviews.py
+++ b/examples/amazon_reviews.py
@@ -250,7 +250,7 @@ def main() -> None:
     # === Step 4: print the output ===
     print("\n=== Discovered schema ===")
     for i, facet in enumerate(t.schema_):
-        print(f"\nFacet {i}: {facet['name']} ({facet['type']})")
+        print(f"\nFacet {i}: {facet['name']} ({facet['kind']})")
         print(f"  {facet['definition']}")
         for value in facet["values"]:
             print(f"  - {value}")

--- a/src/typologist/_pipeline.py
+++ b/src/typologist/_pipeline.py
@@ -207,7 +207,7 @@ _FACET_RESPONSE_SCHEMA = {
     "type": "object",
     "properties": {
         "name": {"type": "string"},
-        "type": {"type": "string", "enum": ["categorical"]},
+        "kind": {"type": "string", "enum": ["categorical"]},
         "values": {
             "type": "array",
             "items": {"type": "string"},
@@ -215,7 +215,7 @@ _FACET_RESPONSE_SCHEMA = {
         },
         "definition": {"type": "string"},
     },
-    "required": ["name", "type", "values", "definition"],
+    "required": ["name", "kind", "values", "definition"],
 }
 
 
@@ -246,7 +246,7 @@ def _synthesize_facet(
 
     response = schema_llm.call_structured(prompt, _FACET_RESPONSE_SCHEMA)
 
-    for key in ("name", "type", "values", "definition"):
+    for key in ("name", "kind", "values", "definition"):
         if key not in response:
             raise RuntimeError(f"schema_llm response missing required field '{key}': {response!r}")
 
@@ -277,7 +277,7 @@ def _synthesize_facet(
 
     facet = {
         "name": name,
-        "type": response["type"],
+        "kind": response["kind"],
         "values": values,
         "definition": response["definition"],
         "labeling_prompt_template": labeling_template,

--- a/src/typologist/_prompts.py
+++ b/src/typologist/_prompts.py
@@ -12,7 +12,7 @@ Identify a single categorical axis along which these {object_description} vary.{
 Respond with only valid JSON of the form:
 {{
   "name": "<lowercase snake_case identifier>",
-  "type": "categorical",
+  "kind": "categorical",
   "values": ["<value1>", "<value2>", ...],
   "definition": "<one short sentence explaining what this facet captures>"
 }}

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -9,7 +9,7 @@ from typologist._pipeline import _classify_docs
 def _facet(name="sentiment", values=None):
     return {
         "name": name,
-        "type": "categorical",
+        "kind": "categorical",
         "values": values or ["positive", "neutral", "negative"],
         "definition": "Overall tone.",
         "labeling_prompt_template": "Classify:\n{document}\nRespond with one value.",
@@ -126,7 +126,7 @@ def test_classify_docs_preserves_order_under_concurrency():
 
     facet = {
         "name": "ordered",
-        "type": "categorical",
+        "kind": "categorical",
         "values": [f"value_{i:02d}" for i in range(10)],
         "definition": "",
         "labeling_prompt_template": "{document}",

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -76,13 +76,13 @@ def test_fit_populates_all_fitted_attributes(monkeypatch):
             [
                 {
                     "name": "facet_one",
-                    "type": "categorical",
+                    "kind": "categorical",
                     "values": ["a", "b"],
                     "definition": "first axis",
                 },
                 {
                     "name": "facet_two",
-                    "type": "categorical",
+                    "kind": "categorical",
                     "values": ["x", "y"],
                     "definition": "second axis",
                 },
@@ -119,7 +119,7 @@ def test_fit_preserves_series_index_onto_labels_df(monkeypatch):
         topic_embedder=_FakeTopicEmbedder(),
         naming_llm=lambda p: "x",
         schema_llm=_make_schema_llm(
-            [{"name": "f", "type": "categorical", "values": ["a", "b"], "definition": "d"}]
+            [{"name": "f", "kind": "categorical", "values": ["a", "b"], "definition": "d"}]
         ),
         labeling_llm=lambda p: "a",
     )
@@ -139,7 +139,7 @@ def test_fit_records_callable_labeling_model_as_none(monkeypatch):
         topic_embedder=_FakeTopicEmbedder(),
         naming_llm=lambda p: "x",
         schema_llm=_make_schema_llm(
-            [{"name": "f", "type": "categorical", "values": ["a", "b"], "definition": "d"}]
+            [{"name": "f", "kind": "categorical", "values": ["a", "b"], "definition": "d"}]
         ),
         labeling_llm=lambda p: "a",  # callable => model unknown
     )
@@ -155,7 +155,7 @@ def test_fit_with_metadata_runs_pre_erasure(monkeypatch):
         topic_embedder=_FakeTopicEmbedder(),
         naming_llm=lambda p: "x",
         schema_llm=_make_schema_llm(
-            [{"name": "f", "type": "categorical", "values": ["a", "b"], "definition": "d"}]
+            [{"name": "f", "kind": "categorical", "values": ["a", "b"], "definition": "d"}]
         ),
         labeling_llm=lambda p: "a",
     )
@@ -175,7 +175,7 @@ def test_apply_schema_applies_stored_template():
     schema = [
         {
             "name": "sentiment",
-            "type": "categorical",
+            "kind": "categorical",
             "values": ["positive", "negative"],
             "definition": "tone",
             "labeling_prompt_template": "Classify:\n{document}\nPick one.",
@@ -196,7 +196,7 @@ def test_apply_schema_applies_stored_template():
 def test_apply_schema_accepts_single_facet_dict():
     facet = {
         "name": "f",
-        "type": "categorical",
+        "kind": "categorical",
         "values": ["a", "b"],
         "definition": "d",
         "labeling_prompt_template": "{document}",
@@ -213,7 +213,7 @@ def test_apply_schema_requires_llm_when_facet_has_no_labeling_model():
     schema = [
         {
             "name": "f",
-            "type": "categorical",
+            "kind": "categorical",
             "values": ["a", "b"],
             "definition": "d",
             "labeling_prompt_template": "{document}",
@@ -228,7 +228,7 @@ def test_apply_schema_preserves_series_index():
     schema = [
         {
             "name": "f",
-            "type": "categorical",
+            "kind": "categorical",
             "values": ["a", "b"],
             "definition": "d",
             "labeling_prompt_template": "{document}",

--- a/tests/test_synthesis.py
+++ b/tests/test_synthesis.py
@@ -26,7 +26,7 @@ def test_synthesize_facet_assembles_schema_entry():
     schema_llm = _StubSchemaLLM(
         {
             "name": "contribution_type",
-            "type": "categorical",
+            "kind": "categorical",
             "values": ["empirical_study", "method_paper", "theory"],
             "definition": "What the paper primarily contributes.",
         }
@@ -42,7 +42,7 @@ def test_synthesize_facet_assembles_schema_entry():
     )
 
     assert facet["name"] == "contribution_type"
-    assert facet["type"] == "categorical"
+    assert facet["kind"] == "categorical"
     assert facet["values"] == ["empirical_study", "method_paper", "theory", "Other"]
     assert facet["definition"] == "What the paper primarily contributes."
     assert facet["labeling_model"] == "claude-haiku-4-5"
@@ -55,7 +55,7 @@ def test_synthesize_facet_records_callable_llm_as_none_labeling_model():
     schema_llm = _StubSchemaLLM(
         {
             "name": "f",
-            "type": "categorical",
+            "kind": "categorical",
             "values": ["a", "b"],
             "definition": "d",
         }
@@ -75,7 +75,7 @@ def test_synthesize_facet_rejects_name_collision():
     schema_llm = _StubSchemaLLM(
         {
             "name": "contribution_type",
-            "type": "categorical",
+            "kind": "categorical",
             "values": ["a", "b"],
             "definition": "d",
         }
@@ -95,7 +95,7 @@ def test_synthesize_facet_rejects_duplicate_values():
     schema_llm = _StubSchemaLLM(
         {
             "name": "f",
-            "type": "categorical",
+            "kind": "categorical",
             "values": ["a", "a", "b"],
             "definition": "d",
         }
@@ -115,7 +115,7 @@ def test_synthesize_facet_rejects_too_few_values():
     schema_llm = _StubSchemaLLM(
         {
             "name": "f",
-            "type": "categorical",
+            "kind": "categorical",
             "values": ["only_one"],
             "definition": "d",
         }
@@ -135,7 +135,7 @@ def test_synthesize_facet_rejects_missing_required_field():
     schema_llm = _StubSchemaLLM(
         {
             "name": "f",
-            "type": "categorical",
+            "kind": "categorical",
             # missing "values" and "definition"
         }
     )
@@ -154,7 +154,7 @@ def test_synthesize_facet_appends_other_when_absent():
     schema_llm = _StubSchemaLLM(
         {
             "name": "f",
-            "type": "categorical",
+            "kind": "categorical",
             "values": ["a", "b", "c"],
             "definition": "d",
         }
@@ -175,7 +175,7 @@ def test_synthesize_facet_dedupes_other_case_insensitively():
     schema_llm = _StubSchemaLLM(
         {
             "name": "f",
-            "type": "categorical",
+            "kind": "categorical",
             "values": ["a", "b", "other"],
             "definition": "d",
         }
@@ -195,7 +195,7 @@ def test_synthesize_facet_other_appears_in_labeling_template():
     schema_llm = _StubSchemaLLM(
         {
             "name": "f",
-            "type": "categorical",
+            "kind": "categorical",
             "values": ["a", "b"],
             "definition": "d",
         }
@@ -224,7 +224,7 @@ def test_synthesize_facet_passes_prior_names_to_prompt():
     stub = _CaptureStub(
         {
             "name": "f",
-            "type": "categorical",
+            "kind": "categorical",
             "values": ["a", "b"],
             "definition": "d",
         }


### PR DESCRIPTION
## Summary

Apply the terminology lock from [`docs/glossary.md`](docs/glossary.md): "type" is too loaded in Python (builtin) and pandas (dtype) to use as the dict key for a facet's categorical-vs-ordinal shape. "Kind" is the canonical term.

**Breaking change to the `schema_[i]` dict shape.** Saved 0.0.1 schemas need their `"type"` key renamed to `"kind"` before loading via `apply_schema`. CHANGELOG entry added. Cheap at alpha.

## Renames

- `schema_[i]["type"]` → `schema_[i]["kind"]` (public schema shape)
- `_FACET_RESPONSE_SCHEMA` property key + `"required"` list
- `_synthesize_facet` validation loop and output dict construction
- Synthesis prompt JSON template (LLM-visible): `"type": "categorical"` → `"kind": "categorical"`
- `docs/design.md` schema spec
- Test fixtures across `test_synthesis.py`, `test_end_to_end.py`, `test_classification.py`
- Example code in `examples/amazon_reviews.py` (`facet['type']` → `facet['kind']`)

## Intentionally retained

- **JSON Schema meta keyword `"type"`** (e.g. `"type": "object"`, `"type": "string"`) inside `_FACET_RESPONSE_SCHEMA`'s value shapes and Anthropic `tool_choice`. Not ours to rename.
- **Anthropic SDK attribute access** (`block.type == "tool_use"`). SDK-defined.
- **Metadata description dict's `"type"` field** in `_describe_erased_metadata` / `_format_accounted_for_entry`. It holds `categorical`/`ordinal` too but is purely internal and its key would collide with the entry-discriminator `"kind"` that already exists in the same dict scope. Deferred as a followup if we want full internal consistency there.

## Test plan

- [x] `uv run ruff check src tests` clean
- [x] `uv run ruff format --check src tests` clean
- [x] `uv run pytest` — 106 passed
- [ ] Eyeball CHANGELOG entry wording

🤖 Generated with [Claude Code](https://claude.com/claude-code)