### PR TITLE
Add use_toponymy flag and homemade naming path (#11)

### DIFF
--- a/examples/amazon_reviews.py
+++ b/examples/amazon_reviews.py
@@ -59,7 +59,7 @@ RANDOM_SEED = 0
 # --- helpers ----------------------------------------------------------------
 
 
-def load_reviews(seed: int) -> pd.DataFrame:
+def load_reviews(seed: int, n_per_category: int = 83) -> pd.DataFrame:
     """Stream a stratified sample of Amazon reviews from HuggingFace.
 
     The ``SOURCE_PRODUCT_CATEGORIES`` list below is *input to sampling*, not
@@ -67,6 +67,10 @@ def load_reviews(seed: int) -> pd.DataFrame:
     product categories and draw a balanced number of reviews from each so
     the corpus isn't dominated by one type. Typologist will then discover
     its own categorization from the review text alone (see Step 3 in main).
+
+    ``n_per_category`` defaults to 83 (6 x 83 = ~498 reviews total) for the
+    example here; experiments that want a different size pass a larger value
+    (e.g. 250 -> ~1500).
     """
     from datasets import load_dataset
 
@@ -78,8 +82,7 @@ def load_reviews(seed: int) -> pd.DataFrame:
         "Home_and_Kitchen",
         "Toys_and_Games",
     ]
-    n_per_category = 83  # 6 x 83 = ~498 reviews total
-    stream_window = 3000  # Stream this many per category before sampling
+    stream_window = max(3000, n_per_category * 6)  # Pull enough headroom for big samples
     min_text_chars = 200  # Drop one-liner reviews; they embed poorly
 
     jsonl_url = (

--- a/src/typologist/_homemade.py
+++ b/src/typologist/_homemade.py
@@ -1,0 +1,141 @@
+"""Toponymy-replacement naming path for evaluating whether Toponymy is load-bearing.
+
+This module exists to support the experiment in issue #11: does a minimal,
+single-K, exemplar-based cluster-naming pipeline match Toponymy's facet quality?
+Routed via ``Typologist(use_toponymy=False)``. Not part of the public API.
+
+What it does:
+- EVoC clustering at a single layer (no multi-scale hierarchy)
+- For each non-noise cluster, pick the ``exemplars_k`` documents nearest the
+  cluster's centroid in the embedding space
+- One LLM call per cluster to produce a short topic name from those exemplars
+
+Returns a ``_NamingResult`` with ``topic_names`` of length 1 (single layer),
+which the schema-synthesis prompt consumes the same way it consumes Toponymy's
+multi-layer hierarchy.
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+
+import numpy as np
+import pandas as pd
+from evoc import EVoC
+from tqdm.auto import tqdm
+
+from typologist._llm import _LLM
+from typologist._pipeline import _NamingResult
+
+_NAMING_PROMPT = """\
+Below are {n_exemplars} {object_description} from one cluster within {corpus_description}.
+
+{exemplars_block}
+
+Propose a short topic name (3 to 7 words) describing what these {object_description} \
+have in common. Respond with the topic name only, no explanation, no quotes."""
+
+
+def _format_exemplars(exemplars: list[str], max_chars_per_exemplar: int = 600) -> str:
+    """Render the exemplars block for the naming prompt.
+
+    Long documents get truncated so the prompt stays bounded; the trade-off is
+    accepted because cluster-naming is a gist task and the cluster geometry has
+    already done most of the work of pulling related documents together.
+    """
+    lines: list[str] = []
+    for i, doc in enumerate(exemplars, start=1):
+        text = doc if len(doc) <= max_chars_per_exemplar else doc[:max_chars_per_exemplar] + "..."
+        lines.append(f"--- Exemplar {i} ---\n{text}")
+    return "\n\n".join(lines)
+
+
+def _select_exemplars(
+    documents: pd.Series,
+    embeddings: np.ndarray,
+    cluster_positions: np.ndarray,
+    exemplars_k: int,
+) -> list[str]:
+    """Return up to ``exemplars_k`` documents nearest to the cluster centroid.
+
+    Operates in the cluster's own subset of ``embeddings`` and returns the
+    documents themselves (text), in centroid-distance order.
+    """
+    cluster_embeddings = embeddings[cluster_positions]
+    centroid = cluster_embeddings.mean(axis=0)
+    dists = np.linalg.norm(cluster_embeddings - centroid, axis=1)
+    k = min(exemplars_k, cluster_positions.size)
+    nearest_within = np.argsort(dists)[:k]
+    nearest_positions = cluster_positions[nearest_within]
+    return [documents.iloc[p] for p in nearest_positions]
+
+
+def _run_homemade_naming(
+    documents: pd.Series,
+    embeddings: np.ndarray,
+    naming_llm: _LLM,
+    object_description: str,
+    corpus_description: str,
+    exemplars_k: int = 8,
+    max_concurrency: int = 10,
+    verbose: bool = False,
+) -> _NamingResult:
+    """Cluster with EVoC, name each cluster from its centroid-nearest exemplars.
+
+    EVoC's ``labels_`` (single layer of cluster assignments, ``-1`` for noise)
+    is used directly; multi-scale layers are intentionally ignored. Returns a
+    single-layer ``_NamingResult`` whose ``topic_names[0]`` lists the named
+    clusters in the order EVoC assigned them.
+    """
+    evoc = EVoC()
+    evoc.fit(embeddings)
+    raw_labels = np.asarray(evoc.labels_)
+
+    cluster_ids = sorted(int(lbl) for lbl in np.unique(raw_labels) if lbl != -1)
+    if not cluster_ids:
+        raise RuntimeError(
+            "EVoC produced no clusters (all points were noise). The homemade "
+            "naming path needs at least one non-noise cluster to propose a facet."
+        )
+
+    exemplars_per_cluster: list[list[str]] = []
+    for cid in cluster_ids:
+        positions = np.where(raw_labels == cid)[0]
+        exemplars_per_cluster.append(
+            _select_exemplars(documents, embeddings, positions, exemplars_k)
+        )
+
+    def name_one(exemplars: list[str]) -> str:
+        prompt = _NAMING_PROMPT.format(
+            n_exemplars=len(exemplars),
+            object_description=object_description,
+            corpus_description=corpus_description,
+            exemplars_block=_format_exemplars(exemplars),
+        )
+        return naming_llm(prompt).strip()
+
+    if max_concurrency > 1:
+        with ThreadPoolExecutor(max_workers=max_concurrency) as executor:
+            results_iter = executor.map(name_one, exemplars_per_cluster)
+            if verbose:
+                results_iter = tqdm(
+                    results_iter,
+                    total=len(exemplars_per_cluster),
+                    desc="naming clusters",
+                    unit="cluster",
+                )
+            names = list(results_iter)
+    else:
+        iterator = (
+            tqdm(exemplars_per_cluster, desc="naming clusters", unit="cluster")
+            if verbose
+            else exemplars_per_cluster
+        )
+        names = [name_one(ex) for ex in iterator]
+
+    return _NamingResult(
+        topic_names=[names],
+        topic_name_vectors=[np.array(names, dtype=object)],
+        cluster_count=len(names),
+        hierarchy_depth=1,
+    )

--- a/src/typologist/_homemade.py
+++ b/src/typologist/_homemade.py
@@ -82,14 +82,22 @@ def _run_homemade_naming(
 ) -> _NamingResult:
     """Cluster with EVoC, name each cluster from its centroid-nearest exemplars.
 
-    EVoC's ``labels_`` (single layer of cluster assignments, ``-1`` for noise)
-    is used directly; multi-scale layers are intentionally ignored. Returns a
+    Uses EVoC's finest (most-clusters) layer rather than ``labels_`` (EVoC's
+    auto-pick of the layer with the fewest noise points): the auto-pick
+    sometimes returns 4 coarse clusters when the underlying data has 11+
+    natural ones, and the schema-synthesis LLM benefits from finer-grained
+    cluster names. Toponymy similarly feeds all layers (finest included) into
+    its synthesis prompt; this is the single-layer analog. Returns a
     single-layer ``_NamingResult`` whose ``topic_names[0]`` lists the named
-    clusters in the order EVoC assigned them.
+    clusters.
     """
     evoc = EVoC()
     evoc.fit(embeddings)
-    raw_labels = np.asarray(evoc.labels_)
+    layers = list(evoc.cluster_layers_) or [np.asarray(evoc.labels_)]
+    finest_layer = max(
+        layers, key=lambda layer: len(set(int(lbl) for lbl in np.unique(layer) if lbl != -1))
+    )
+    raw_labels = np.asarray(finest_layer)
 
     cluster_ids = sorted(int(lbl) for lbl in np.unique(raw_labels) if lbl != -1)
     if not cluster_ids:

--- a/src/typologist/_pipeline.py
+++ b/src/typologist/_pipeline.py
@@ -162,8 +162,8 @@ def _erase_metadata(
 
 
 @dataclass(frozen=True)
-class _ToponymyResult:
-    """Topic-naming output from one Toponymy run."""
+class _NamingResult:
+    """Topic-naming output from one naming-stage run (Toponymy or homemade)."""
 
     topic_names: list[list[str]]
     topic_name_vectors: list[np.ndarray]
@@ -179,7 +179,7 @@ def _run_toponymy(
     object_description: str,
     corpus_description: str,
     verbose: bool,
-) -> _ToponymyResult:
+) -> _NamingResult:
     """Construct a Toponymy instance with EVoCClusterer and run it on embeddings.
 
     Toponymy's ``fit`` expects a third ``clusterable_vectors`` argument, which
@@ -195,7 +195,7 @@ def _run_toponymy(
         verbose=verbose,
     )
     topo.fit(documents.tolist(), embeddings, embeddings)
-    return _ToponymyResult(
+    return _NamingResult(
         topic_names=topo.topic_names_,
         topic_name_vectors=topo.topic_name_vectors_,
         cluster_count=max(len(layer) for layer in topo.topic_names_),
@@ -340,7 +340,7 @@ def _classify_docs(
 
 def _build_facet_diagnostics(
     synthesis_prompt: str,
-    toponymy_result: _ToponymyResult,
+    naming_result: _NamingResult,
     labels: pd.Series,
     embeddings_pre_erasure: np.ndarray,
     values: list[str],
@@ -383,8 +383,8 @@ def _build_facet_diagnostics(
 
     return {
         "synthesis_prompt": synthesis_prompt,
-        "cluster_count": toponymy_result.cluster_count,
-        "hierarchy_depth": toponymy_result.hierarchy_depth,
+        "cluster_count": naming_result.cluster_count,
+        "hierarchy_depth": naming_result.hierarchy_depth,
         "entropy_bits": {
             "observed": observed,
             "uniform": uniform,

--- a/src/typologist/typologist.py
+++ b/src/typologist/typologist.py
@@ -6,6 +6,7 @@ from typing import Any
 import numpy as np
 import pandas as pd
 
+from typologist._homemade import _run_homemade_naming
 from typologist._llm import _resolve_llm
 from typologist._pipeline import (
     _build_facet_diagnostics,
@@ -38,6 +39,7 @@ class Typologist:
         noise_label: str = "Unlabelled",
         verbose: bool = False,
         max_concurrency: int = 10,
+        use_toponymy: bool = True,
     ) -> None:
         self.n_facets = n_facets
         self.topic_embedder = topic_embedder
@@ -50,6 +52,7 @@ class Typologist:
         self.noise_label = noise_label
         self.verbose = verbose
         self.max_concurrency = max_concurrency
+        self.use_toponymy = use_toponymy
 
     def fit(
         self,
@@ -85,18 +88,29 @@ class Typologist:
         diagnostics: list[dict] = []
 
         for _ in range(self.n_facets):
-            topo = _run_toponymy(
-                documents=inputs.documents,
-                embeddings=working,
-                topic_embedder=self.topic_embedder,
-                naming_llm=naming,
-                object_description=self.object_description,
-                corpus_description=self.corpus_description,
-                verbose=self.verbose,
-            )
+            if self.use_toponymy:
+                naming_result = _run_toponymy(
+                    documents=inputs.documents,
+                    embeddings=working,
+                    topic_embedder=self.topic_embedder,
+                    naming_llm=naming,
+                    object_description=self.object_description,
+                    corpus_description=self.corpus_description,
+                    verbose=self.verbose,
+                )
+            else:
+                naming_result = _run_homemade_naming(
+                    documents=inputs.documents,
+                    embeddings=working,
+                    naming_llm=naming,
+                    object_description=self.object_description,
+                    corpus_description=self.corpus_description,
+                    max_concurrency=self.max_concurrency,
+                    verbose=self.verbose,
+                )
 
             facet, synthesis_prompt = _synthesize_facet(
-                cluster_hierarchy=topo.topic_names,
+                cluster_hierarchy=naming_result.topic_names,
                 schema_llm=schema_llm,
                 labeling_llm_model_name=labeling_llm.model_name,
                 object_description=self.object_description,
@@ -117,7 +131,7 @@ class Typologist:
             diagnostics.append(
                 _build_facet_diagnostics(
                     synthesis_prompt=synthesis_prompt,
-                    toponymy_result=topo,
+                    naming_result=naming_result,
                     labels=labels,
                     embeddings_pre_erasure=working,
                     values=facet["values"],

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -5,11 +5,11 @@ import math
 import numpy as np
 import pandas as pd
 
-from typologist._pipeline import _build_facet_diagnostics, _ToponymyResult
+from typologist._pipeline import _build_facet_diagnostics, _NamingResult
 
 
-def _topo_result(cluster_count=8, hierarchy_depth=3):
-    return _ToponymyResult(
+def _naming_result(cluster_count=8, hierarchy_depth=3):
+    return _NamingResult(
         topic_names=[["x"]],
         topic_name_vectors=[np.array([], dtype=object)],
         cluster_count=cluster_count,
@@ -21,7 +21,7 @@ def test_diagnostics_passes_through_synthesis_prompt_and_counts():
     labels = pd.Series(pd.Categorical(["a"] * 4, categories=["a", "b"]))
     out = _build_facet_diagnostics(
         synthesis_prompt="prompt text",
-        toponymy_result=_topo_result(cluster_count=12, hierarchy_depth=4),
+        naming_result=_naming_result(cluster_count=12, hierarchy_depth=4),
         labels=labels,
         embeddings_pre_erasure=np.zeros((4, 8)),
         values=["a", "b"],
@@ -35,7 +35,7 @@ def test_diagnostics_entropy_uniform_is_log2_n_values():
     labels = pd.Series(pd.Categorical(["a", "b", "c", "d"], categories=["a", "b", "c", "d"]))
     out = _build_facet_diagnostics(
         synthesis_prompt="",
-        toponymy_result=_topo_result(),
+        naming_result=_naming_result(),
         labels=labels,
         embeddings_pre_erasure=np.zeros((4, 8)),
         values=["a", "b", "c", "d"],
@@ -50,7 +50,7 @@ def test_diagnostics_entropy_observed_matches_distribution():
     )
     out = _build_facet_diagnostics(
         synthesis_prompt="",
-        toponymy_result=_topo_result(),
+        naming_result=_naming_result(),
         labels=labels,
         embeddings_pre_erasure=np.zeros((8, 8)),
         values=["a", "b", "c"],
@@ -63,7 +63,7 @@ def test_diagnostics_entropy_delta_is_observed_minus_uniform():
     labels = pd.Series(pd.Categorical(["a", "b", "c", "d"], categories=["a", "b", "c", "d"]))
     out = _build_facet_diagnostics(
         synthesis_prompt="",
-        toponymy_result=_topo_result(),
+        naming_result=_naming_result(),
         labels=labels,
         embeddings_pre_erasure=np.zeros((4, 8)),
         values=["a", "b", "c", "d"],
@@ -74,7 +74,7 @@ def test_diagnostics_entropy_delta_is_observed_minus_uniform():
     labels_concentrated = pd.Series(pd.Categorical(["a"] * 4, categories=["a", "b", "c", "d"]))
     out2 = _build_facet_diagnostics(
         synthesis_prompt="",
-        toponymy_result=_topo_result(),
+        naming_result=_naming_result(),
         labels=labels_concentrated,
         embeddings_pre_erasure=np.zeros((4, 8)),
         values=["a", "b", "c", "d"],
@@ -103,7 +103,7 @@ def test_diagnostics_exemplars_are_nearest_to_centroid():
     )
     out = _build_facet_diagnostics(
         synthesis_prompt="",
-        toponymy_result=_topo_result(),
+        naming_result=_naming_result(),
         labels=labels,
         embeddings_pre_erasure=embeddings,
         values=["a", "b"],
@@ -119,7 +119,7 @@ def test_diagnostics_exemplars_respect_k_limit():
     labels = pd.Series(pd.Categorical(["a"] * 10, categories=["a", "b"]))
     out = _build_facet_diagnostics(
         synthesis_prompt="",
-        toponymy_result=_topo_result(),
+        naming_result=_naming_result(),
         labels=labels,
         embeddings_pre_erasure=np.random.default_rng(0).random((10, 4)),
         values=["a", "b"],
@@ -133,7 +133,7 @@ def test_diagnostics_exemplars_handle_fewer_docs_than_k():
     labels = pd.Series(pd.Categorical(["a", "b", "a"], categories=["a", "b"]))
     out = _build_facet_diagnostics(
         synthesis_prompt="",
-        toponymy_result=_topo_result(),
+        naming_result=_naming_result(),
         labels=labels,
         embeddings_pre_erasure=np.ones((3, 4)),
         values=["a", "b"],
@@ -151,7 +151,7 @@ def test_diagnostics_exemplars_preserve_user_index():
     )
     out = _build_facet_diagnostics(
         synthesis_prompt="",
-        toponymy_result=_topo_result(),
+        naming_result=_naming_result(),
         labels=labels,
         embeddings_pre_erasure=np.ones((3, 4)),
         values=["a"],

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -193,6 +193,7 @@ def test_fit_with_use_toponymy_false_routes_through_homemade(monkeypatch):
 
         def fit(self, x):
             self.labels_ = np.array([0, 0, 1, 1])
+            self.cluster_layers_ = [self.labels_]
             return self
 
     monkeypatch.setattr(_homemade, "EVoC", _FakeEVoC)

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -171,6 +171,50 @@ def test_fit_with_metadata_runs_pre_erasure(monkeypatch):
     assert t.embeddings_residualized_.shape == (n, 8)
 
 
+def test_fit_with_use_toponymy_false_routes_through_homemade(monkeypatch):
+    """When use_toponymy=False, Toponymy should not be touched and EVoC should drive naming."""
+    from typologist import _homemade, _pipeline
+
+    sentinel_topo_called = False
+
+    class _ExplodeIfCalled:
+        def __init__(self, **kwargs):
+            nonlocal sentinel_topo_called
+            sentinel_topo_called = True
+
+        def fit(self, *args, **kwargs):
+            raise AssertionError("Toponymy should not be invoked when use_toponymy=False")
+
+    monkeypatch.setattr(_pipeline, "Toponymy", _ExplodeIfCalled)
+
+    class _FakeEVoC:
+        def __init__(self, **kwargs):
+            pass
+
+        def fit(self, x):
+            self.labels_ = np.array([0, 0, 1, 1])
+            return self
+
+    monkeypatch.setattr(_homemade, "EVoC", _FakeEVoC)
+
+    t = Typologist(
+        n_facets=1,
+        topic_embedder=_FakeTopicEmbedder(),
+        naming_llm=lambda p: "named_cluster",
+        schema_llm=_make_schema_llm(
+            [{"name": "f", "kind": "categorical", "values": ["a", "b"], "definition": "d"}]
+        ),
+        labeling_llm=lambda p: "a",
+        use_toponymy=False,
+    )
+
+    t.fit(["d1", "d2", "d3", "d4"], np.eye(4, 8, dtype=np.float32))
+
+    assert sentinel_topo_called is False
+    assert t.facet_diagnostics_[0]["hierarchy_depth"] == 1
+    assert t.facet_diagnostics_[0]["cluster_count"] == 2
+
+
 def test_apply_schema_applies_stored_template():
     schema = [
         {

--- a/tests/test_homemade.py
+++ b/tests/test_homemade.py
@@ -9,7 +9,14 @@ from typologist._llm import _CallableLLM
 
 
 class _FakeEVoC:
-    """Returns canned cluster labels passed in via class attribute."""
+    """Returns canned cluster labels passed in via class attribute.
+
+    Mirrors EVoC's surface: both ``labels_`` (the auto-picked layer) and
+    ``cluster_layers_`` (the multi-scale list). The homemade module reads
+    from ``cluster_layers_`` (finest-by-cluster-count); tests pass a single
+    layer that doubles as both ``labels_`` and the only entry in
+    ``cluster_layers_``.
+    """
 
     next_labels: np.ndarray = np.array([])
     last_fit_input: np.ndarray | None = None
@@ -20,6 +27,7 @@ class _FakeEVoC:
     def fit(self, x):
         _FakeEVoC.last_fit_input = x
         self.labels_ = _FakeEVoC.next_labels
+        self.cluster_layers_ = [_FakeEVoC.next_labels]
         return self
 
 
@@ -131,6 +139,52 @@ def test_run_homemade_naming_raises_when_all_noise(monkeypatch):
             corpus_description="c",
             max_concurrency=1,
         )
+
+
+def test_run_homemade_naming_picks_finest_layer_not_labels(monkeypatch):
+    """When EVoC returns multiple layers, homemade should use the one with the most clusters.
+
+    EVoC's ``labels_`` attribute is the auto-picked layer (often optimized for low
+    noise, which can mean coarse). The homemade pipeline benefits from finer
+    granularity, so it should explicitly pick the layer with the most clusters.
+    """
+    from typologist import _homemade
+
+    class _MultiLayerFakeEVoC:
+        def __init__(self, **kwargs):
+            pass
+
+        def fit(self, x):
+            # labels_ = coarse (2 clusters), cluster_layers_[0] = fine (5 clusters).
+            # The homemade module should pick the fine layer.
+            self.labels_ = np.array([0, 0, 0, 1, 1, 1, 1, 1])
+            self.cluster_layers_ = [
+                np.array([0, 1, 2, 3, 4, 0, 1, 2]),  # 5 clusters
+                np.array([0, 0, 0, 1, 1, 1, 1, 1]),  # 2 clusters
+            ]
+            return self
+
+    monkeypatch.setattr(_homemade, "EVoC", _MultiLayerFakeEVoC)
+
+    docs = pd.Series([f"doc_{i}" for i in range(8)])
+    embeddings = np.eye(8, 4, dtype=np.float32)
+    seen_prompts: list[str] = []
+
+    def fake_naming(prompt: str) -> str:
+        seen_prompts.append(prompt)
+        return "n"
+
+    result = _run_homemade_naming(
+        documents=docs,
+        embeddings=embeddings,
+        naming_llm=_CallableLLM(fake_naming),
+        object_description="o",
+        corpus_description="c",
+        max_concurrency=1,
+    )
+    # 5 clusters in the fine layer -> 5 naming calls, 5 entries in topic_names[0]
+    assert len(seen_prompts) == 5
+    assert result.cluster_count == 5
 
 
 def test_run_homemade_naming_concurrent_path_preserves_cluster_order(monkeypatch):

--- a/tests/test_homemade.py
+++ b/tests/test_homemade.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from typologist._homemade import _run_homemade_naming, _select_exemplars
+from typologist._llm import _CallableLLM
+
+
+class _FakeEVoC:
+    """Returns canned cluster labels passed in via class attribute."""
+
+    next_labels: np.ndarray = np.array([])
+    last_fit_input: np.ndarray | None = None
+
+    def __init__(self, **kwargs):
+        pass
+
+    def fit(self, x):
+        _FakeEVoC.last_fit_input = x
+        self.labels_ = _FakeEVoC.next_labels
+        return self
+
+
+def _patch_evoc(monkeypatch, labels: np.ndarray) -> None:
+    from typologist import _homemade
+
+    _FakeEVoC.next_labels = labels
+    monkeypatch.setattr(_homemade, "EVoC", _FakeEVoC)
+
+
+def test_select_exemplars_returns_centroid_nearest():
+    docs = pd.Series([f"doc_{i}" for i in range(5)])
+    embeddings = np.array(
+        [[0.0, 0.0], [1.0, 0.0], [2.0, 0.0], [3.0, 0.0], [10.0, 0.0]],
+        dtype=np.float32,
+    )
+    positions = np.array([0, 1, 2, 3])  # exclude the outlier at position 4
+    # centroid of those 4 = (1.5, 0.0); distances 1.5, 0.5, 0.5, 1.5
+    out = _select_exemplars(docs, embeddings, positions, exemplars_k=2)
+    assert set(out) == {"doc_1", "doc_2"}
+
+
+def test_select_exemplars_caps_at_cluster_size():
+    docs = pd.Series([f"doc_{i}" for i in range(3)])
+    embeddings = np.zeros((3, 4), dtype=np.float32)
+    out = _select_exemplars(docs, embeddings, np.array([0, 1, 2]), exemplars_k=10)
+    assert len(out) == 3
+
+
+def test_run_homemade_naming_skips_noise_and_names_each_cluster(monkeypatch):
+    # 6 docs: cluster 0 has docs 0-1, cluster 1 has docs 2-3, noise (-1) docs 4-5.
+    labels = np.array([0, 0, 1, 1, -1, -1])
+    _patch_evoc(monkeypatch, labels)
+
+    docs = pd.Series([f"doc_{i}" for i in range(6)])
+    embeddings = np.eye(6, 8, dtype=np.float32)
+
+    seen_prompts: list[str] = []
+
+    def fake_naming(prompt: str) -> str:
+        seen_prompts.append(prompt)
+        # Return a deterministic name based on which exemplars are present
+        for i in range(6):
+            if f"doc_{i}" in prompt:
+                return f"name_for_{i}"
+        return "unknown"
+
+    result = _run_homemade_naming(
+        documents=docs,
+        embeddings=embeddings,
+        naming_llm=_CallableLLM(fake_naming),
+        object_description="thing",
+        corpus_description="things",
+        exemplars_k=4,
+        max_concurrency=1,
+        verbose=False,
+    )
+
+    # Two non-noise clusters -> two prompts -> two names in a single layer.
+    assert len(seen_prompts) == 2
+    assert result.hierarchy_depth == 1
+    assert result.cluster_count == 2
+    assert len(result.topic_names) == 1
+    assert len(result.topic_names[0]) == 2
+    # Each prompt should have rendered the corpus_description and the object plural.
+    assert all("things" in p for p in seen_prompts)
+    assert all("thing" in p for p in seen_prompts)
+
+
+def test_run_homemade_naming_passes_embedding_to_evoc(monkeypatch):
+    labels = np.array([0, 0, 0])
+    _patch_evoc(monkeypatch, labels)
+
+    embeddings = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=np.float32)
+    _run_homemade_naming(
+        documents=pd.Series(["a", "b", "c"]),
+        embeddings=embeddings,
+        naming_llm=_CallableLLM(lambda p: "n"),
+        object_description="o",
+        corpus_description="c",
+        max_concurrency=1,
+    )
+    np.testing.assert_array_equal(_FakeEVoC.last_fit_input, embeddings)
+
+
+def test_run_homemade_naming_strips_whitespace_from_names(monkeypatch):
+    _patch_evoc(monkeypatch, np.array([0, 0]))
+
+    result = _run_homemade_naming(
+        documents=pd.Series(["a", "b"]),
+        embeddings=np.zeros((2, 4), dtype=np.float32),
+        naming_llm=_CallableLLM(lambda p: "  padded name  \n"),
+        object_description="o",
+        corpus_description="c",
+        max_concurrency=1,
+    )
+    assert result.topic_names[0] == ["padded name"]
+
+
+def test_run_homemade_naming_raises_when_all_noise(monkeypatch):
+    _patch_evoc(monkeypatch, np.array([-1, -1, -1]))
+
+    with pytest.raises(RuntimeError, match="no clusters"):
+        _run_homemade_naming(
+            documents=pd.Series(["a", "b", "c"]),
+            embeddings=np.zeros((3, 4), dtype=np.float32),
+            naming_llm=_CallableLLM(lambda p: "n"),
+            object_description="o",
+            corpus_description="c",
+            max_concurrency=1,
+        )
+
+
+def test_run_homemade_naming_concurrent_path_preserves_cluster_order(monkeypatch):
+    # Three clusters; order of names_ in the result must match the sorted cluster ids.
+    labels = np.array([2, 2, 0, 0, 1, 1])
+    _patch_evoc(monkeypatch, labels)
+
+    docs = pd.Series([f"doc_{i}" for i in range(6)])
+    embeddings = np.eye(6, 4, dtype=np.float32)
+
+    def fake_naming(prompt: str) -> str:
+        for i in range(6):
+            if f"doc_{i}" in prompt:
+                # The first doc per cluster identifies it
+                return f"cluster_for_{i}"
+        return "?"
+
+    result = _run_homemade_naming(
+        documents=docs,
+        embeddings=embeddings,
+        naming_llm=_CallableLLM(fake_naming),
+        object_description="o",
+        corpus_description="c",
+        exemplars_k=2,
+        max_concurrency=4,
+    )
+    # sorted cluster ids: 0, 1, 2 -> first doc indices: 2, 4, 0
+    assert result.topic_names[0] == ["cluster_for_2", "cluster_for_4", "cluster_for_0"]


### PR DESCRIPTION
## Summary

Adds an opt-in `use_toponymy: bool = True` constructor argument to `Typologist` and a parallel `_run_homemade_naming` path that replaces Toponymy with: single-layer EVoC clustering, centroid-nearest exemplar selection, one LLM call per cluster to name. Defaults to `True`, so user-visible behavior is unchanged.

This is the implementation half of #11. The empirical evaluation half ran on a separate branch (`experiments/toponymy-vs-homemade`) and is summarized below; the verdict and follow-up live in a separate issue.

## Files

- `src/typologist/_homemade.py` (new): the alternative naming path. Uses EVoC's finest layer (most clusters) rather than `labels_` (EVoC's auto-pick of the lowest-noise layer) so the schema-synthesis LLM gets richer signal.
- `src/typologist/typologist.py`: new `use_toponymy` kwarg; `fit()` branches between `_run_toponymy` and `_run_homemade_naming`.
- `src/typologist/_pipeline.py`: rename `_ToponymyResult` → `_NamingResult` (both paths populate it).
- `tests/test_homemade.py` (new): 8 tests covering exemplar selection, noise dropping, naming-prompt rendering, finest-layer choice, concurrent ordering.
- `tests/test_end_to_end.py`: adds an integration test that asserts Toponymy is not invoked when `use_toponymy=False`.
- `examples/amazon_reviews.py`: parameterizes `load_reviews(n_per_category=83)` so the same loader serves examples and larger experiments.

## Empirical findings (from #11 evaluation)

Six configurations tested (4 corpora × 2 sizes × 3 seeds-on-amazon, ~\$22 total spend):

| corpus / size | seeds | result |
|---|---|---|
| amazon n≈500 | 0, 1, 2 | wash; same axes both pipelines, every seed |
| amazon n=1500 | 0 | wash; Toponymy hierarchy depth 2-3 didn't surface different schema |
| arxiv n≈330 (top-6 categories) | 0 | wash |
| ag_news n=500 | 0 | wash after homemade-finest-layer fix |

Key observations:
- Same F0/F1 axes discovered every time across both pipelines (e.g. `product_category` then `review_sentiment` on amazon vanilla; `review_sentiment` after `product_category` erasure).
- Homemade ~30-40% faster on every arm.
- Toponymy's multi-scale hierarchy did not produce different schemas at scale, even when depth-3 hierarchies appeared at n=1500.
- Both pipelines equally seed-stable (no Toponymy-specific stability advantage).
- Toponymy modestly richer value vocabulary on F0-erasure (e.g. 5-point sentiment vs 4-point) on some configs.

## What this PR does NOT do

- Doesn't change the default (`use_toponymy=True`).
- Doesn't drop the Toponymy dependency.
- Doesn't make Toponymy optional in `pyproject.toml`.

The follow-up question (\"should we make Toponymy an optional extra?\") is captured in a separate issue.

## Test plan

- [ ] `uv run pytest` passes (115 tests).
- [ ] `uv run ruff check src tests && uv run ruff format --check src tests` passes.
- [ ] Smoke: `Typologist(..., use_toponymy=False).fit(...)` runs end-to-end on a small corpus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)